### PR TITLE
Adds on_config_changed event handler and runtime deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
-# training-operator
-Kubeflow Training Operator
+# Training Operator
+
+## Overview
+
+This repository hosts the Kubernetes Training Operator for Kubeflow training jobs.
+
+## Description
+
+The [Kubeflow Training Operator][1] provides Kubernetes custom resources to run distributed or non-distributed training jobs, such as TFJobs and PytorchJobs. The Training Operator in this repository is a Python script which wraps the latest released Kubeflow Training Operator [manifests][2], providing lifecycle management and handling events (install, upgrade, integrate, remove). It is one of the [Charmed Kubeflow][3] operators.
+
+## Usage
+
+While it is possible to deploy the Training Operator as a standalone operator, it works best when deployed alongside other components included in the Kubeflow bundle. For installation steps, please refer to the [installation][4] guide.
+
+[1]: https://www.kubeflow.org/docs/components/training/
+[2]: https://github.com/kubeflow/manifests/tree/master/apps/training-operator
+[3]: https://github.com/canonical/bundle-kubeflow
+[4]: https://charmed-kubeflow.io/docs/install

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,0 +1,17 @@
+type: "charm"
+bases:
+  - build-on:
+    - name: "ubuntu"
+      channel: "20.04"
+    run-on:
+    - name: "ubuntu"
+      channel: "20.04"
+parts:
+  kubectl:
+    plugin: dump
+    source: .
+    override-pull: |
+      curl -sSLO https://dl.k8s.io/release/v1.22.1/bin/linux/amd64/kubectl
+      chmod +x kubectl
+    build-packages:
+      - curl

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -15,3 +15,6 @@ parts:
       chmod +x kubectl
     build-packages:
       - curl
+  charm:
+    build-packages:
+      - git

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,5 @@
+options:
+  container-port:
+    type: string
+    default: "8080"
+    description: Port used by the monitoring service

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,19 @@
+name: training-operator
+display-name: Training Operator
+summary: Tools for distributed or non-distributed training on Kubernetes
+description: |
+  Training Operator provides Kubernetes custom resources that make it
+  easy to run distributed or non-distributed training jobs on Kubernetes.
+  This charm deploys the Operator configured for use with Kubeflow to
+  Kubernetes models in Juju.
+maintainers: [Juju Developers <juju@lists.ubuntu.com>]
+tags: [ai, bigdata, kubeflow, machine-learning, tensorflow, pytorch]
+containers:
+  training-operator:
+    resource: training-operator-image
+resources:
+  training-operator-image:
+    type: oci-image
+    description: OCI image for training-operator
+    auto-fetch: true
+    upstream-source: kubeflow/training-operator:4d4cf6485eb40d4e6e4badb03d341b8b78c2ec92

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/canonical/operator/#egg=ops

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+import logging
+
+from ops.main import main
+from ops.pebble import Layer
+from ops.charm import CharmBase
+from ops.model import ActiveStatus, WaitingStatus, MaintenanceStatus
+
+logger = logging.getLogger(__name__)
+
+
+class TrainingOperatorCharm(CharmBase):
+    """ A Juju Charm for Training Operator"""
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        self.logger = logging.getLogger(__name__)
+
+        self._name = self.model.app.name
+        self._namespace = self.model.name
+        self._manager_service = "manager"
+
+        self.framework.observe(self.on.install, self._on_install)
+        self.framework.observe(self.on.config_changed, self._on_config_changed)
+        self.framework.observe(self.on.training_operator_pebble_ready, self._on_training_operator_pebble_ready)
+
+    def _training_operator_layer(self):
+        """
+        Returns a Pebble configuration layer for Kubeflow Training Operator
+        This piece of software takes care of the deployment part of the
+        training-operator
+        """
+        # /manager is the entrypoint on Kubeflow's training-operator image
+        return {
+            "summary": "training-operator layer",
+            "description": "pebble config layer for training-operator",
+            "services": {
+                self._manager_service: {
+                    "override": "replace",
+                    "summary": "entrypoint of the training-operator image",
+                    "command": "/manager",
+                    "startup": "enabled",
+                    "environment": {
+                        # containerPort: 8080 is accessed by the monitoring service
+                        # on port 8080. Leaving this for documentation purposes only.
+                        "CONTAINER_PORT": int(self.model.config["container-port"]),
+                        "MY_POD_NAMESPACE": self._namespace,
+                        "MY_POD_NAME": self._name,
+                        }
+                }
+            },
+        }
+
+    def _on_training_operator_pebble_ready(self, event):
+        """
+        Placeholder for pebble ready event
+        """
+        pass
+
+    def _on_config_changed(self, event):
+        """
+        Placeholder for config changed event
+        """
+        pass
+
+    def _on_install(self, event):
+        """
+        Placeholder for install event
+        """
+        pass
+
+if __name__ == "__main__":
+    main(TrainingOperatorCharm)


### PR DESCRIPTION
Please note this is a draft and because it depends on #1 and #2 , it shouldn't be merged before them. As in #2 , this PR's target branch is `dnplas/1.4-dev` since `main` is still empty. Once we start populating the repository, we can merge on `main`. Your comments and edit suggestions are welcomed. I'll work on applicable changes in my fork.

For this PR, let's just focus on commits: 
def836b Adds requirements.txt and enables git in charmcraft.yaml
deb14d7 src/charm.py: adds _on_config_changed event handler