### PR TITLE
Adds integration tests, testing dependencies and tox.ini for integration testing

### DIFF
--- a/examples/pytorchjob.yaml
+++ b/examples/pytorchjob.yaml
@@ -1,0 +1,32 @@
+apiVersion: "kubeflow.org/v1"
+kind: PyTorchJob
+metadata:
+  name: pytorch-simple
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: OnFailure
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
+              imagePullPolicy: Always
+              command:
+                - "python3"
+                - "/opt/pytorch-mnist/mnist.py"
+                - "--epochs=1"
+    Worker:
+      replicas: 1
+      restartPolicy: OnFailure
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
+              imagePullPolicy: Always
+              command:
+                - "python3"
+                - "/opt/pytorch-mnist/mnist.py"
+                - "--epochs=1"

--- a/examples/tfjob.yaml
+++ b/examples/tfjob.yaml
@@ -1,0 +1,17 @@
+apiVersion: "kubeflow.org/v1"
+kind: TFJob
+metadata:
+  name: tfjob-simple
+spec:
+   tfReplicaSpecs:
+     Worker:
+       replicas: 2
+       restartPolicy: OnFailure
+       template:
+         spec:
+           containers:
+             - name: tensorflow
+               image: gcr.io/kubeflow-ci/tf-mnist-with-summaries:1.0
+               command:
+                 - "python"
+                 - "/var/tf_mnist/mnist_with_summaries.py"

--- a/examples/xgboostjob.yaml
+++ b/examples/xgboostjob.yaml
@@ -1,0 +1,42 @@
+apiVersion: kubeflow.org/v1
+kind: XGBoostJob
+metadata:
+  name: xgboost-simple
+spec:
+  xgbReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+          - name: xgboost
+            image: docker.io/merlintang/xgboost-dist-iris:1.1
+            ports:
+            - containerPort: 9991
+              name: xgboostjob-port
+            imagePullPolicy: Always
+            args:
+              - --job_type=Train
+              - --xgboost_parameter=objective:multi:softprob,num_class:3
+              - --n_estimators=10
+              - --learning_rate=0.1
+              - --model_path=/tmp/xgboost-model
+              - --model_storage_type=local
+    Worker:
+      replicas: 2
+      restartPolicy: ExitCode
+      template:
+        spec:
+          containers:
+          - name: xgboost
+            image: docker.io/merlintang/xgboost-dist-iris:1.1
+            ports:
+            - containerPort: 9991
+              name: xgboostjob-port
+            imagePullPolicy: Always
+            args:
+              - --job_type=Train
+              - --xgboost_parameter="objective:multi:softprob,num_class:3"
+              - --n_estimators=10
+              - --learning_rate=0.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,3 @@
+pytest<6.3
+pyyaml<6.1
+tenacity<8.1

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -106,7 +106,8 @@ def test_create_training_jobs(ops_test: OpsTest, example: str):
         assert job_status in [
             "Running",
             "Succeeded",
-        ], f"{job_object.metadata.name} was not running or did not succeed"
+        ], f"{job_object.metadata.name} was not running or did not succeed" \
+        f" (status == {job_status})"
 
     assert_get_job()
     assert_job_status_running_success()

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,0 +1,112 @@
+import glob
+from pathlib import Path
+
+import yaml
+import pytest
+import tenacity
+import lightkube.generic_resource
+
+from lightkube import codecs, Client
+from pytest_operator.plugin import OpsTest
+from tenacity import retry, wait_exponential, stop_after_delay
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+APP_NAME = "training-operator"
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest):
+    """Build the charm and deploy it with trust=True.
+
+    Assert on the unit status.
+    """
+    charm_under_test = await ops_test.build_charm(".")
+    image_path = METADATA["resources"]["training-operator-image"]["upstream-source"]
+    resources = {"training-operator-image": image_path}
+
+    await ops_test.model.deploy(
+        charm_under_test, resources=resources, application_name=APP_NAME, trust=True
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=60 * 10
+    )
+    assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
+
+def lightkube_create_global_resources() -> dict:
+    """Returns a dict with GenericNamespacedResource as value for each CRD key."""
+    crds_kinds = [
+        crd["spec"]["names"]
+        for crd in yaml.safe_load_all(Path("./src/crds_manifests.yaml").read_text())
+    ]
+    jobs_classes = {}
+    for kind in crds_kinds:
+        job_class = lightkube.generic_resource.create_namespaced_resource(
+            group="kubeflow.org", version="v1", kind=kind["kind"], plural=kind["plural"]
+        )
+        jobs_classes[kind["kind"]] = job_class
+    return jobs_classes
+
+# TODO: Kubeflow upstream MXNet examples use GPU.
+# Not testing MXNetjobs until we have a CPU mxjob example.
+JOBS_CLASSES = lightkube_create_global_resources()
+
+@pytest.mark.parametrize("example", glob.glob("examples/*.yaml"))
+def test_create_training_jobs(ops_test: OpsTest, example: str):
+    """Validates that a training job can be created and is running.
+
+    Asserts on the *Job status.
+    """
+    namespace = ops_test.model_name
+    lightkube_client = lightkube.Client()
+
+    # Set up for creating an object of kind *Job
+    job_yaml = yaml.safe_load(Path(example).read_text())
+    job_object = lightkube.codecs.load_all_yaml(yaml.dump(job_yaml))[0]
+    job_class = JOBS_CLASSES[job_object.kind]
+
+    # Create *Job and check if it exists where expected
+    lightkube_client.create(job_object, namespace=namespace)
+
+    # Allow the resource to be created
+    @tenacity.retry(
+        wait=tenacity.wait_exponential(multiplier=1, min=1, max=15),
+        stop=tenacity.stop_after_delay(30),
+        reraise=True,
+    )
+    def assert_get_job():
+        """Asserts on the job.
+
+        Retries multiple times using tenacity to allow time for the training job
+        to be created.
+        """
+        job = lightkube_client.get(
+            job_class, name=job_object.metadata.name, namespace=namespace
+        )
+
+        assert job is not None, f"{job_object.metadata.name} does not exist"
+
+    # Wait for the *Job to have a status
+    # TODO: change this workaround after
+    # we have an implementation in lightkube
+    @tenacity.retry(
+        wait=tenacity.wait_exponential(multiplier=2, min=1, max=120),
+        stop=tenacity.stop_after_attempt(3),
+        reraise=True
+    )
+    def assert_job_status_running_success():
+        """Asserts on the job status.
+
+        Retries multiple times using tenacity to allow time for the training job
+        to change its status from None -> Created -> Running/Succeeded.
+        """
+        job_status = lightkube_client.get(
+            job_class.Status, name=job_object.metadata.name, namespace=namespace
+        ).status["conditions"][-1]["type"]
+
+        # Check wether the last status of *Job is Running/Success
+        assert job_status in [
+            "Running",
+            "Succeeded",
+        ], f"{job_object.metadata.name} was not running or did not succeed"
+
+    assert_get_job()
+    assert_job_status_running_success()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+skipsdist = True
+
+[testenv]
+setenv =
+	PYTHONPATH={toxinidir}/src:{toxinidir}/lib
+deps =
+	-rtest-requirements.txt
+	-rrequirements.txt
+passenv =
+    KUBECONFIG
+
+[testenv:integration]
+deps =
+    {[testenv]deps}
+    pytest-operator
+commands = pytest -v --tb native --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration


### PR DESCRIPTION
This PR introduces the following changes:
* tests/integration: adds integration tests
* Adds tox.ini and test-requirements.txt
* Adds examples/ with simple training jobs manifests (excluding mxnet)

> NOTE: I understand that multiple asserts in a single test is not desirable, please let me know if you've an alternative for `test_can_i_create_training_jobs`.