### PR TITLE
workflows/publish.yaml: use canonical/charmhub-upload-action@0.1.0 for publish job

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,41 +5,19 @@ on:
     branches:
       - main
       - track/**
-  schedule:
-    - cron: '0 8 * * THU'
-
+  pull_request:
+    types:
+      - opened
+      - edited
+    branches:
+      - branch/**
 jobs:
   charm:
     name: Publish Charm
     runs-on: ubuntu-latest
-
     steps:
-    - name: Check out code
-      uses: actions/checkout@v2
-
-    - name: Install dependencies
-      run: |
-        set -eux
-        sudo snap install charmcraft --classic --channel=latest/candidate
-        sudo snap install yq
-
-    - name: Charm
-      env:
-        CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
-      run: |
-        set -eux
-
-        mkdir -p ~/snap/charmcraft/common/config/
-        echo "$CHARMCRAFT_CREDENTIALS" > ~/snap/charmcraft/common/config/charmcraft.credentials
-
-        NAME=$(yq eval '.name' metadata.yaml)
-        IMAGE=$(yq eval '.resources.oci-image.upstream-source' metadata.yaml)
-        REV=$(git rev-parse --abbrev-ref HEAD)
-        TRACK=$([[ "$REV" =~ ^(master|main)$ ]] && echo "latest" || echo "${REV#track/}")
-
-        charmcraft pack --destructive-mode
-        charmcraft upload-resource "$NAME" oci-image --image "$IMAGE"
-        REVISION=$(charmcraft resource-revisions "$NAME" oci-image 2>&1 | awk 'FNR == 2 {print $1}')
-        charmcraft upload ./*.charm \
-            --release=$TRACK/edge \
-            --resource=oci-image:"$REVISION"
+    - uses: actions/checkout@v2
+    # TODO: Update to @main when https://github.com/canonical/charmhub-upload-action/pull/3 merged
+    - uses: canonical/charmhub-upload-action@branch/upload-charm-revisions
+      with:
+        credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}


### PR DESCRIPTION
Using the Github [action](https://github.com/canonical/charmhub-upload-action) instead of manually publishing the charm.