### PR TITLE
Removed prometheus-app direct relation in test

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,5 +18,5 @@ resources:
 provides:
   metrics-endpoint:
     interface: prometheus_scrape
-  grafana-dashboards:
+  grafana-dashboard:
     interface: grafana_dashboard

--- a/src/charm.py
+++ b/src/charm.py
@@ -54,7 +54,7 @@ class TrainingOperatorCharm(CharmBase):
 
         self.dashboard_provider = GrafanaDashboardProvider(
             charm=self,
-            relation_name="grafana-dashboards",
+            relation_name="grafana-dashboard",
         )
 
         self.framework.observe(self.on.install, self._on_install)

--- a/src/charm.py
+++ b/src/charm.py
@@ -52,10 +52,7 @@ class TrainingOperatorCharm(CharmBase):
         }
         self._context = {"namespace": self._namespace, "app_name": self._name}
 
-        self.dashboard_provider = GrafanaDashboardProvider(
-            charm=self,
-            relation_name="grafana-dashboard",
-        )
+        self.dashboard_provider = GrafanaDashboardProvider(self)
 
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.config_changed, self._on_config_changed)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -135,7 +135,6 @@ async def test_prometheus_grafana_integration(ops_test: OpsTest):
     await ops_test.model.deploy(grafana, channel="latest/beta")
     await ops_test.model.add_relation(prometheus, grafana)
     await ops_test.model.add_relation(APP_NAME, grafana)
-    await ops_test.model.add_relation(prometheus, APP_NAME)
     await ops_test.model.deploy(
         prometheus_scrape_charm,
         channel="latest/beta",


### PR DESCRIPTION
Update of https://github.com/canonical/training-operator/pull/27 according to latest Observability Team's review: removed the direct relation between prometheus and training-operator.