### PR TITLE
Update charming actions

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,11 +1,28 @@
+# reusable workflow triggered by other actions
 name: Tests
 
 on:
-  pull_request:
-  schedule:
-    - cron: '0 8 * * TUE'
+  workflow_call:
+    secrets:
+      charmcraft-credentials:
+        required: true
 
 jobs:
+
+  lib-check:
+    name: Check libraries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Check libs
+        uses: canonical/charming-actions/check-libraries@1.0.3
+        with:
+          credentials: "${{ secrets.charmcraft-credentials }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -1,0 +1,23 @@
+name: Test and publish to branch
+
+# On pull_request, we:
+# * always publish to charmhub at latest/edge/branchname
+# * always run tests
+
+on:
+  pull_request:
+
+jobs:
+
+  tests:
+    name: Run Tests
+    uses: ./.github/workflows/integration.yaml
+    secrets:
+      charmcraft-credentials: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"
+
+  # publish runs in parallel with tests, as we always publish in this situation
+  publish-charm:
+    name: Publish Charm
+    uses: ./.github/workflows/publish.yaml
+    secrets:
+      charmcraft-credentials: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -1,0 +1,31 @@
+name: Publish to edge if tests passed
+
+# On push to a "special" branch, we:
+# * always publish to charmhub at latest/edge/branchname
+# * always run tests
+# where a "special" branch is one of main/master or track/**, as
+# by convention these branches are the source for a corresponding
+# charmhub edge channel.
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - track/**
+
+jobs:
+
+  tests:
+    name: Run Tests
+    uses: ./.github/workflows/integration.yaml
+    secrets:
+      charmcraft-credentials: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"
+
+  # publish runs in series with tests, and only publishes if tests passes
+  publish-charm:
+    name: Publish Charm
+    needs: tests
+    uses: ./.github/workflows/publish.yaml
+    secrets:
+      charmcraft-credentials: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,27 +1,28 @@
+# reusable workflow triggered by other actions
 name: Publish
 
 on:
-  push:
-    branches:
-      - master
-      - main
-      - track/**
-  pull_request:
-    branches:
-      - master
-      - main
-      - track/**
+  workflow_call:
+    secrets:
+      charmcraft-credentials:
+        required: true
 
 jobs:
+
   publish-charm:
     name: Publish Charm
     runs-on: ubuntu-latest
-    # Only publish to charmhub if we are pushing to a special branch or running PRs from something named `branch/*`
-    if: (github.event_name == 'push') ||  (startsWith( github.head_ref, 'branch/' ))
     steps:
-      - uses: actions/checkout@v2
-      - uses: canonical/charming-actions/upload-charm@1.0.0
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
-          credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          channel: latest/edge
+          fetch-depth: 0
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@1.0.3
+        id: channel
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@1.0.3
+        with:
+          credentials: "${{ secrets.charmcraft-credentials }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          channel: "${{ steps.channel.outputs.name }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,4 @@
+# reusable workflow triggered manually
 name: Release charm to other tracks and channels
 
 on:
@@ -8,10 +9,7 @@ on:
         required: true
       origin-channel:
         description: 'Origin Channel'
-        required: false
-      rev:
-        description: 'Revision number'
-        required: false
+        required: true
 
 jobs:
   promote-charm:
@@ -20,10 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Release charm to channel
-        uses: canonical/charming-actions/release-charm@promote-charm
+        uses: canonical/charming-actions/release-charm@1.0.3
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           destination-channel: ${{ github.event.inputs.destination-channel }}
           origin-channel: ${{ github.event.inputs.origin-channel }}
-          revision: ${{ github.event.inputs.rev }}

--- a/.github/workflows/weekly_ci.yaml
+++ b/.github/workflows/weekly_ci.yaml
@@ -1,0 +1,13 @@
+name: Run weekly tests
+
+on:
+  schedule:
+    - cron: '0 8 * * TUE'
+
+jobs:
+
+  tests:
+    name: Run Tests
+    uses: ./.github/workflows/integration.yaml
+    secrets:
+      charmcraft-credentials: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"


### PR DESCRIPTION
Charming actions updated according to the ones agreed on template-operator charm.
The aim was to:
- update release charm action
- have two publish actions for `on: push` and `on: pull_request`:
	- on pull_request, publish to branch no matter if tests passed (tests and publish should run simultaneously)
	- on push, publish to latest/edge only if tests passed

- avoid re-running the tests on pull_request
- use reusable workflows in order to avoid duplication of code.

Note: this is a single-charm repo with one resource.