### PR TITLE
ci: pin microk8s 1.22 in integration job

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -67,7 +67,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
             provider: microk8s
-            channel: 1.21/stable
+            channel: 1.22/stable
             charmcraft-channel: latest/candidate
 
       - name: Run integration tests


### PR DESCRIPTION
Change to be able to test training-operator 1.5.0 in microk8s 1.22 

