### PR TITLE
Add and update examples to be used in integration tests

### DIFF
--- a/examples/mpijob.yaml
+++ b/examples/mpijob.yaml
@@ -1,0 +1,53 @@
+apiVersion: kubeflow.org/v1
+kind: MPIJob
+metadata:
+  name: tensorflow-mnist
+spec:
+  slotsPerWorker: 1
+  runPolicy:
+    cleanPodPolicy: Running
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+          - image: horovod/horovod:0.20.0-tf2.3.0-torch1.6.0-mxnet1.5.0-py3.7-cpu
+            name: mpi
+            command:
+            - mpirun
+            args:
+            - -np
+            - "2"
+            - --allow-run-as-root
+            - -bind-to
+            - none
+            - -map-by
+            - slot
+            - -x
+            - LD_LIBRARY_PATH
+            - -x
+            - PATH
+            - -mca
+            - pml
+            - ob1
+            - -mca
+            - btl
+            - ^openib
+            - python
+            - /examples/tensorflow2_mnist.py
+            resources:
+              limits:
+                cpu: 1
+                memory: 2Gi
+    Worker:
+      replicas: 2
+      template:
+        spec:
+          containers:
+          - image: horovod/horovod:0.20.0-tf2.3.0-torch1.6.0-mxnet1.5.0-py3.7-cpu
+            name: mpi
+            resources:
+              limits:
+                cpu: 2
+                memory: 4Gi

--- a/examples/mpijob.yaml
+++ b/examples/mpijob.yaml
@@ -39,9 +39,9 @@ spec:
             resources:
               limits:
                 cpu: 1
-                memory: 2Gi
+                memory: 1Gi
     Worker:
-      replicas: 2
+      replicas: 1
       template:
         spec:
           containers:
@@ -49,5 +49,5 @@ spec:
             name: mpi
             resources:
               limits:
-                cpu: 2
-                memory: 4Gi
+                cpu: 1
+                memory: 2Gi

--- a/examples/xgboostjob.yaml
+++ b/examples/xgboostjob.yaml
@@ -1,7 +1,7 @@
 apiVersion: kubeflow.org/v1
 kind: XGBoostJob
 metadata:
-  name: xgboost-simple
+  name: xgboost-dist-iris-test-train
 spec:
   xgbReplicaSpecs:
     Master:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -81,7 +81,7 @@ def test_create_training_jobs(ops_test: OpsTest, example: str):
     # Allow the resource to be created
     @tenacity.retry(
         wait=tenacity.wait_exponential(multiplier=1, min=1, max=15),
-        stop=tenacity.stop_after_delay(30),
+        stop=tenacity.stop_after_delay(50),
         reraise=True,
     )
     def assert_get_job():
@@ -100,8 +100,8 @@ def test_create_training_jobs(ops_test: OpsTest, example: str):
     # TODO: change this workaround after
     # we have an implementation in lightkube
     @tenacity.retry(
-        wait=tenacity.wait_exponential(multiplier=2, min=1, max=30),
-        stop=tenacity.stop_after_attempt(10),
+        wait=tenacity.wait_exponential(multiplier=2, min=1, max=50),
+        stop=tenacity.stop_after_attempt(100),
         reraise=True,
     )
     def assert_job_status_running_success():


### PR DESCRIPTION
Update all examples based on the latest versions of [simple jobs](https://github.com/kubeflow/training-operator/tree/master/examples). This PR also adds mpijobs, as that is now supported in charmed kubeflow 1.5.

>Important: all mxjobs [examples](https://github.com/kubeflow/training-operator/tree/v1.5.0-rc.0/examples/mxnet) require GPU. I'm not adding a test for that at the moment until we have a solution for it. Feel free to make suggestions. 