### PR TITLE
use chisme update_layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 __pycache__
 .idea
 .tox
+.coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-lightkube<=0.8.1
+lightkube==0.11.0
 jinja2<3.1
 ops==1.3.0
+charmed-kubeflow-chisme

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -92,7 +92,7 @@ class TestCharm(unittest.TestCase):
                         ),
                     )
 
-    @patch("charm.TrainingOperatorCharm._update_layer")
+    @patch("charm.update_layer")
     @patch("charm.TrainingOperatorCharm._patch_resource")
     @patch("charm.ApiError", _FakeApiError)
     def test_config_changed_event(self, patch, update):
@@ -116,8 +116,7 @@ class TestCharm(unittest.TestCase):
                 ),
             )
 
-    @patch("charm.TrainingOperatorCharm._update_layer")
-    def test_on_training_operator_pebble_ready(self, update):
+    def test_on_training_operator_pebble_ready(self):
         self.harness.container_pebble_ready("training-operator")
 
         # Check the layer gets created


### PR DESCRIPTION
Update training-operator to use the `update_layer` function in chisme, updated tests to match
CI would fail until [this pr](https://github.com/canonical/charmed-kubeflow-chisme/pull/25) is merged and published. Tested locally with `git+https://github.com/canonical/charmed-kubeflow-chisme@KF-605/update-layer-handler` in `requirements.txt`