### PR TITLE
Upgrade image for 1.7 release

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,7 +14,7 @@ resources:
   training-operator-image:
     type: oci-image
     description: OCI image for training-operator
-    upstream-source: kubeflow/training-operator:v1-b8004ae
+    upstream-source: kubeflow/training-operator:v1-27e5499
 provides:
   metrics-endpoint:
     interface: prometheus_scrape


### PR DESCRIPTION
bump image from training operator 1.6.0-rc.0 to 1.6.0-rc.1 for kubeflow 1.7 release