### PR TITLE
fix: use charmed-kubernetes/actions-operator@main

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup operator environment
-        uses: claudiubelu/actions-operator@18ebf92ae3043bd3dd15238e5d9b662d7ba08daf
+        uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
           channel: 1.24/stable


### PR DESCRIPTION
to be consistent in all of our repos, use `charmed-kubernetes/actions-operator@main` in `Setup operator environment`