### PR TITLE
fix: remove BlockedStatus statements in charm code

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -180,10 +180,7 @@ class TrainingOperatorCharm(CharmBase):
 
     def _on_pebble_ready(self, _):
         """Configure started container."""
-        if not self.container.can_connect():
-            raise ErrorWithStatus(
-                f"Container {self._container_name} failed to start", BlockedStatus
-            )
+        self._check_container_connection()
         self.main(_)
 
     def _on_install(self, _):

--- a/src/charm.py
+++ b/src/charm.py
@@ -147,8 +147,7 @@ class TrainingOperatorCharm(CharmBase):
             self.k8s_resource_handler.apply()
             self.crd_resource_handler.apply()
         except ApiError as e:
-            self.logger.exception(f"Failed to create K8S resources, with error: {e}")
-            raise e
+            raise ApiError("Failed to create K8S resources") from e
         self.model.unit.status = MaintenanceStatus("K8S resources created")
 
     def _update_layer(self) -> None:
@@ -162,8 +161,7 @@ class TrainingOperatorCharm(CharmBase):
                 self.logger.info("Pebble plan updated with new configuration, replaning")
                 self.container.replan()
             except ChangeError as e:
-                self.logger.exception(f"Failed to replan, with error: {e}")
-                raise e
+                raise ChangeError("Failed to replan") from e
 
     def main(self, _) -> None:
         """Perform all required actions the Charm."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -131,10 +131,6 @@ class TrainingOperatorCharm(CharmBase):
 
     def _check_container_connection(self):
         """Check if connection can be made with container."""
-        # FIXME: if the container is unreachable, setting the unit
-        # to MaintenanceStatus won't have any effect in the execution
-        # which may cause issues if there is an attempt of starting
-        # the workload service or updating the pebble layer (which replans)
         if not self.container.can_connect():
             raise ErrorWithStatus("Pod startup is not complete", MaintenanceStatus)
 
@@ -182,7 +178,6 @@ class TrainingOperatorCharm(CharmBase):
 
     def _on_pebble_ready(self, _):
         """Configure started container."""
-        self._check_container_connection()
         self.main(_)
 
     def _on_install(self, _):

--- a/src/charm.py
+++ b/src/charm.py
@@ -5,7 +5,7 @@
 
 import logging
 
-from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
+from charmed_kubeflow_chisme.exceptions import ErrorWithStatus, ErrorStatusWithMessage
 from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler
 from charmed_kubeflow_chisme.lightkube.batch import delete_many
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
@@ -147,7 +147,7 @@ class TrainingOperatorCharm(CharmBase):
             self.k8s_resource_handler.apply()
             self.crd_resource_handler.apply()
         except ApiError as e:
-            raise ApiError("Failed to create K8S resources") from e
+            raise ErrorStatusWithMessage("Failed to create K8S resources")
         self.model.unit.status = MaintenanceStatus("K8S resources created")
 
     def _update_layer(self) -> None:
@@ -161,7 +161,7 @@ class TrainingOperatorCharm(CharmBase):
                 self.logger.info("Pebble plan updated with new configuration, replaning")
                 self.container.replan()
             except ChangeError as e:
-                raise ChangeError("Failed to replan") from e
+                raise ErrorStatusWithMessage("Failed to replan") from e
 
     def main(self, _) -> None:
         """Perform all required actions the Charm."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -131,6 +131,10 @@ class TrainingOperatorCharm(CharmBase):
 
     def _check_container_connection(self):
         """Check if connection can be made with container."""
+        # FIXME: if the container is unreachable, setting the unit
+        # to MaintenanceStatus won't have any effect in the execution
+        # which may cause issues if there is an attempt of starting
+        # the workload service or updating the pebble layer (which replans)
         if not self.container.can_connect():
             raise ErrorWithStatus("Pod startup is not complete", MaintenanceStatus)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -5,7 +5,7 @@
 
 import logging
 
-from charmed_kubeflow_chisme.exceptions import ErrorWithStatus, ErrorStatusWithMessage
+from charmed_kubeflow_chisme.exceptions import ErrorWithStatus, GenericCharmRuntimeError
 from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler
 from charmed_kubeflow_chisme.lightkube.batch import delete_many
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
@@ -147,7 +147,7 @@ class TrainingOperatorCharm(CharmBase):
             self.k8s_resource_handler.apply()
             self.crd_resource_handler.apply()
         except ApiError as e:
-            raise ErrorStatusWithMessage("Failed to create K8S resources")
+            raise GenericCharmRuntimeError("Failed to create K8S resources") from e
         self.model.unit.status = MaintenanceStatus("K8S resources created")
 
     def _update_layer(self) -> None:
@@ -161,7 +161,7 @@ class TrainingOperatorCharm(CharmBase):
                 self.logger.info("Pebble plan updated with new configuration, replaning")
                 self.container.replan()
             except ChangeError as e:
-                raise ErrorStatusWithMessage("Failed to replan") from e
+                raise GenericCharmRuntimeError("Failed to replan") from e
 
     def main(self, _) -> None:
         """Perform all required actions the Charm."""


### PR DESCRIPTION
This PR includes:
   
* fix: remove BlockedStatus statements in charm code
    A BlockedStatus mean a human has to manually intervene to ublock
    the unit and let it proceed. There were some conditions where no
    external intervention could ublock the unit. Adding appropriate
    logging and exceptions to catch errors and set status correctly.
    
    Partially fixes canonical/bundle-kubeflow#549

* fix: use _check_can_connect() in pebble ready event handler

Please merge after ~~#89~~ #93 , the CI (integration and publish jobs) is failing due to SDI dependencies incompatibilities.