### PR TITLE
reuse ci

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -1,27 +1,19 @@
 # reusable workflow triggered by other actions
-name: Tests
+name: CI
 
 on:
   workflow_call:
     secrets:
-      charmcraft-credentials:
+      CHARMCRAFT_CREDENTIALS:
         required: true
 
 jobs:
-
   lib-check:
     name: Check libraries
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Check libs
-        uses: canonical/charming-actions/check-libraries@2.2.3
-        with:
-          credentials: "${{ secrets.charmcraft-credentials }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_quality-checks.yaml@main
+    secrets: inherit
+    with:
+        charm-path: "."
 
   lint:
     name: Lint

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -12,12 +12,11 @@ jobs:
   tests:
     name: Run Tests
     uses: ./.github/workflows/integrate.yaml
-    secrets:
-      charmcraft-credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+    secrets: inherit
 
   # publish runs in parallel with tests, as we always publish in this situation
   publish-charm:
     name: Publish Charm
     uses: ./.github/workflows/publish.yaml
-    secrets:
-      CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+    secrets: inherit
+

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -14,16 +14,15 @@ on:
     - track/**
 
 jobs:
+
   tests:
     name: Run Tests
     uses: ./.github/workflows/integrate.yaml
-    secrets:
-      charmcraft-credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+    secrets: inherit
 
   # publish runs in series with tests, and only publishes if tests passes
   publish-charm:
     name: Publish Charm
     needs: tests
     uses: ./.github/workflows/publish.yaml
-    secrets:
-      CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+    secrets: inherit


### PR DESCRIPTION
replace check libraries pattern with reused workflow. That will allow to change CI only in one place