### PR TITLE
build: remove all SDI dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,8 +32,6 @@ idna==2.10
     #   rfc3986
 jinja2==3.1.2
     # via charmed-kubeflow-chisme
-jsonschema==3.2.0
-    # via serialized-data-interface
 lightkube==0.11.0
     # via
     #   -r ./requirements.in
@@ -50,7 +48,6 @@ ops==1.5.4
     # via
     #   -r ./requirements.in
     #   charmed-kubeflow-chisme
-    #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
 pyrsistent==0.19.2
@@ -59,17 +56,12 @@ pyyaml==5.4
     # via
     #   lightkube
     #   ops
-    #   serialized-data-interface
-requests==2.25.0
-    # via serialized-data-interface
 rfc3986[idna2008]==1.5.0
     # via httpx
 ruamel-yaml==0.17.21
     # via charmed-kubeflow-chisme
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
-serialized-data-interface==0.4.0
-    # via -r ./requirements.in
 six==1.16.0
     # via jsonschema
 sniffio==1.3.0


### PR DESCRIPTION
SDI is not used in this charm, there is no need for SDI dependencies.

Fixes #83 CI.