### PR TITLE
feat: bump training-operator image

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,7 +14,7 @@ resources:
   training-operator-image:
     type: oci-image
     description: OCI image for training-operator
-    upstream-source: kubeflow/training-operator:v1-27e5499
+    upstream-source: kubeflow/training-operator:v1-66aa635
 provides:
   metrics-endpoint:
     interface: prometheus_scrape


### PR DESCRIPTION
Use latest 1.6.0 image.