### PR TITLE
fix: Use force on all client.apply() calls

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -194,7 +194,11 @@ class TrainingOperatorCharm(CharmBase):
             except ChangeError as e:
                 raise GenericCharmRuntimeError("Failed to replan") from e
 
-    def _on_event(self, _, force_conflicts: bool = False) -> None:
+    # TODO: force_conflicts=True due to
+    #  https://github.com/canonical/training-operator/issues/104
+    #  Remove this if [this pr](https://github.com/canonical/charmed-kubeflow-chisme/pull/65)
+    #  merges.
+    def _on_event(self, _, force_conflicts: bool = True) -> None:
         """Perform all required actions the Charm.
 
         Args:
@@ -219,11 +223,17 @@ class TrainingOperatorCharm(CharmBase):
     def _on_install(self, _):
         """Perform installation only actions."""
         # apply K8S resources to speed up deployment
-        self._apply_k8s_resources()
+        # TODO: force_conflicts=True due to
+        #  https://github.com/canonical/training-operator/issues/104
+        #  Remove this if [this pr](https://github.com/canonical/charmed-kubeflow-chisme/pull/65)
+        #  merges.
+        self._apply_k8s_resources(force_conflicts=True)
 
     def _on_upgrade(self, _):
         """Perform upgrade steps."""
         # force conflict resolution in K8S resources update
+        #  TODO: Remove force_conflicts if
+        #   [this pr](https://github.com/canonical/charmed-kubeflow-chisme/pull/65) merges.
         self._on_event(_, force_conflicts=True)
 
     def _on_remove(self, _):


### PR DESCRIPTION
This adds `force=True` to app lightkube.Client.apply() calls due to issues with conflicting resources, like described [here](https://github.com/canonical/training-operator/issues/104).  This does work around the issue in #104, but likely we should keep #104 open until we have a better standard solution. 

### Testing instructions
(same as #104)
```
charmcraft pack
juju deploy training-operator --channel 1.5/stable --trust
# wait to settle
juju refresh training-operator --path ./training-operator_ubuntu-20.04-amd64.charm  --resource training-operator-image=kubeflow/training-operator:v1-66aa635
```