### PR TITLE
feat: updated get images script without branch checkout for track/1.6

### DIFF
--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# This script returns list of container images that are managed by this charm and/or its workload
+#
+# dynamic list
+IMAGE_LIST=()
+IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
+printf "%s\n" "${IMAGE_LIST[@]}"
+


### PR DESCRIPTION
Used by CVE scanning workflows and can be used to collect images URL for airgapped setup. Script is specific for track/1.i6 branch to capture all images for that branch. Branch is handled in kubeflow-ci and bundle automation using bundle file.

Summary of changes:
- Re-designed get images script to retrieve all images for current branch. Branch management is done outside of this script.