### PR TITLE
update tox.ini's update-requirements

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,9 +31,11 @@ allowlist_externals =
     find
     pip-compile
     xargs
-commands = 
-; uses 'bash -c' because piping didn't work in regular tox commands
-  bash -c 'find . -type f -name "requirements*.in" | xargs --replace=\{\} pip-compile --resolver=backtracking \{\}'
+commands =
+    ; we must preserve the order of compilation, since each *.in file depends on some *.txt file.
+    ; For example, requirements-unit.in depends on requirements.txt and we must compile first
+    ; requirements.txt to ensure that requirements-unit.txt get the same dependency as the requirements.txt
+    bash -c 'for pattern in "requirements.in" "requirements-fmt.in" "requirements*.in"; do find . -type f -name "$pattern" -exec bash -c "cd \$(dirname "{}") && pip-compile --resolver=backtracking \$(basename "{}")" \;; done'
 deps =
     pip-tools
 description = Update requirements files by executing pip-compile on all requirements*.in files, including those in subdirs.


### PR DESCRIPTION
Updates tox.ini's `update-requirements` as described in https://github.com/canonical/argo-operators/pull/100