### PR TITLE
build: bump juju 2.9.44.0, sdi->0.7.0, pyyaml->6.0.1

### DIFF
--- a/requirements-integration.in
+++ b/requirements-integration.in
@@ -1,4 +1,5 @@
-juju<3.1
+# Pinning to <3.0 due to compatibility with the 2.9 controller version and 3.0 not being maintained anymore
+juju<3.0
 pytest-operator
 pyyaml
 tenacity

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -8,8 +8,6 @@ anyio==3.6.2
     # via
     #   -r ./requirements.txt
     #   httpcore
-appnope==0.1.3
-    # via ipython
 asttokens==2.2.1
     # via stack-data
 attrs==22.2.0
@@ -82,7 +80,7 @@ jinja2==3.1.2
     #   -r ./requirements.txt
     #   charmed-kubeflow-chisme
     #   pytest-operator
-juju==3.0.4
+juju==2.9.44.0
     # via
     #   -r ./requirements-integration.in
     #   pytest-operator
@@ -174,7 +172,7 @@ python-dateutil==2.8.2
     # via kubernetes
 pytz==2022.7.1
     # via pyrfc3339
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r ./requirements-integration.in
     #   -r ./requirements.txt
@@ -208,6 +206,7 @@ ruamel-yaml-clib==0.2.7
     #   ruamel-yaml
 six==1.16.0
     # via
+    #   asttokens
     #   google-auth
     #   kubernetes
     #   macaroonbakery

--- a/requirements-unit.txt
+++ b/requirements-unit.txt
@@ -74,7 +74,7 @@ pluggy==1.0.0
     # via pytest
 pytest==7.2.2
     # via -r ./requirements-unit.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r ./requirements.txt
     #   lightkube

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ ops==2.1.1
     #   charmed-kubeflow-chisme
 ordered-set==4.1.0
     # via deepdiff
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   lightkube
     #   ops


### PR DESCRIPTION
Bump these package versions to avoid the issues described in https://github.com/canonical/bundle-kubeflow/issues/648.

Part of canonical/bundle-kubeflow#648