### PR TITLE
fix: add training-operator aggregation ClusterRoles

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -51,6 +51,11 @@ jobs:
   integration-test:
     name: Integration
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        tox-environments:
+          - charm-integration
+          - integration-with-profiles
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -65,7 +70,7 @@ jobs:
           juju-channel: 2.9/stable
 
       - name: Run integration tests
-        run: tox -e integration -- --model testing
+        run: tox -e ${{ matrix.tox-environments }} -- --model testing
 
       - name: Capture k8s resources on failure
         run: |

--- a/src/templates/auth_manifests.yaml.j2
+++ b/src/templates/auth_manifests.yaml.j2
@@ -98,3 +98,85 @@ rules:
       - podgroups
     verbs:
       - "*"
+# Source manifests/apps/training-operator/upstream/overlays/kubeflow/kubeflow-training-roles.yaml
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-training-admin
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.authorization.kubeflow.org/aggregate-to-kubeflow-training-admin: "true"
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-training-edit
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-training-admin: "true"
+rules:
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - mpijobs
+      - tfjobs
+      - pytorchjobs
+      - mxjobs
+      - xgboostjobs
+      - paddlejobs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - mpijobs/status
+      - tfjobs/status
+      - pytorchjobs/status
+      - mxjobs/status
+      - xgboostjobs/status
+      - paddlejobs/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-training-view
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+rules:
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - mpijobs
+      - tfjobs
+      - pytorchjobs
+      - mxjobs
+      - xgboostjobs
+      - paddlejobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - mpijobs/status
+      - tfjobs/status
+      - pytorchjobs/status
+      - mxjobs/status
+      - xgboostjobs/status
+      - paddlejobs/status
+    verbs:
+      - get

--- a/tests/integration/profile.yaml
+++ b/tests/integration/profile.yaml
@@ -1,0 +1,11 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+apiVersion: kubeflow.org/v1
+kind: Profile
+metadata:
+  name: profile-example
+spec:
+  owner:
+    kind: User
+    name: userid2@email.com

--- a/tests/integration/test_charm_with_profile.py
+++ b/tests/integration/test_charm_with_profile.py
@@ -70,7 +70,7 @@ async def test_authorization_for_creating_resources(
         check=True,
         fail_msg="Failed to execute kubectl auth",
     )
-    assert stdout == "yes"
+    assert stdout.strip() == "yes"
 
 
 def apply_manifests(lightkube_client: lightkube.Client, yaml_file_path: str):

--- a/tests/integration/test_charm_with_profile.py
+++ b/tests/integration/test_charm_with_profile.py
@@ -115,7 +115,11 @@ def apply_profile(lightkube_client):
 
     # Allow time for the Profile to be created
     try:
-        for attempt in Retrying(stop=(stop_after_attempt(10) | stop_after_delay(30)), wait=wait_exponential(multiplier=1, min=5, max=10), reraise=True):
+        for attempt in Retrying(
+            stop=(stop_after_attempt(10) | stop_after_delay(30)),
+            wait=wait_exponential(multiplier=1, min=5, max=10),
+            reraise=True,
+        ):
             with attempt:
                 lightkube_client.get(profile_resource, name=PROFILE_NAME)
     except RetryError:

--- a/tests/integration/test_charm_with_profile.py
+++ b/tests/integration/test_charm_with_profile.py
@@ -60,7 +60,7 @@ async def test_authorization_for_creating_resources(
     # Set up for creating an object of kind *Job
     job_yaml = yaml.safe_load(Path(example).read_text())
     training_job = job_yaml["kind"]
-    _, stdout, __ = await ops_test.run(
+    _, stdout, _ = await ops_test.run(
         "kubectl",
         "auth",
         "can-i",

--- a/tests/integration/test_charm_with_profile.py
+++ b/tests/integration/test_charm_with_profile.py
@@ -46,7 +46,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     )
 
     await ops_test.model.wait_for_idle(
-        status="active", raised_on_blocked=True, raise_on_error=True, timeout=60 * 10
+        status="active", raise_on_blocked=True, raise_on_error=True, timeout=60 * 10
     )
 
 

--- a/tests/integration/test_charm_with_profile.py
+++ b/tests/integration/test_charm_with_profile.py
@@ -10,7 +10,7 @@ import yaml
 from lightkube import codecs
 from lightkube.generic_resource import create_global_resource
 from pytest_operator.plugin import OpsTest
-from tenacity import RetryError, Retrying, stop_after_attempt, stop_after_delay
+from tenacity import RetryError, Retrying, stop_after_attempt, stop_after_delay, wait_exponential
 
 basedir = Path("./").absolute()
 PROFILE_NAMESPACE = "profile-example"
@@ -115,7 +115,7 @@ def apply_profile(lightkube_client):
 
     # Allow time for the Profile to be created
     try:
-        for attempt in Retrying(stop=(stop_after_attempt(5) | stop_after_delay(30)), reraise=True):
+        for attempt in Retrying(stop=(stop_after_attempt(10) | stop_after_delay(30)), wait=wait_exponential(multiplier=1, min=5, max=10), reraise=True):
             with attempt:
                 lightkube_client.get(profile_resource, name=PROFILE_NAME)
     except RetryError:

--- a/tests/integration/test_charm_with_profile.py
+++ b/tests/integration/test_charm_with_profile.py
@@ -35,11 +35,20 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     # Deploy kubeflow-roles and kubeflow-profiles to create a Profile
     await ops_test.model.deploy(
-        apps=["kubeflow-roles", "kubeflow-profiles"],
+        entity_url="kubeflow-roles",
+        channel="latest/edge",
         status="active",
         raised_on_blocked=True,
         timeout=60 * 10,
     )
+    await ops_test.model.deploy(
+        entity_url="kubeflow-profiles",
+        channel="latest/edge",
+        status="active",
+        raised_on_blocked=True,
+        timeout=60 * 10,
+    )
+
     await ops_test.model.wait_for_idle(
         status="active", raised_on_blocked=True, raise_on_error=True, timeout=60 * 10
     )

--- a/tests/integration/test_charm_with_profile.py
+++ b/tests/integration/test_charm_with_profile.py
@@ -1,6 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 import glob
+import time
 from pathlib import Path
 
 import lightkube
@@ -115,6 +116,9 @@ def apply_profile(lightkube_client):
     # Apply Profile first
     apply_manifests(lightkube_client, PROFILE_FILE_PATH)
 
+    # Allow time for the Profile to be created
+    time.sleep(10)
+                    
     yield
 
     # Remove namespace

--- a/tests/integration/test_charm_with_profile.py
+++ b/tests/integration/test_charm_with_profile.py
@@ -118,7 +118,7 @@ def apply_profile(lightkube_client):
 
     # Allow time for the Profile to be created
     time.sleep(10)
-                    
+
     yield
 
     # Remove namespace

--- a/tests/integration/test_charm_with_profile.py
+++ b/tests/integration/test_charm_with_profile.py
@@ -3,12 +3,12 @@
 import glob
 from pathlib import Path
 
+import lightkube
 import pytest
 import yaml
-from pytest_operator.plugin import OpsTest
-import lightkube
 from lightkube import codecs
 from lightkube.generic_resource import create_global_resource
+from pytest_operator.plugin import OpsTest
 
 basedir = Path("./").absolute()
 PROFILE_NAMESPACE = "profile-example"
@@ -17,6 +17,7 @@ PROFILE_FILE = yaml.safe_load(Path(PROFILE_FILE_PATH).read_text())
 KUBEFLOW_USER_NAME = PROFILE_FILE["spec"]["owner"]["name"]
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = "training-operator"
+
 
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest):
@@ -33,19 +34,39 @@ async def test_build_and_deploy(ops_test: OpsTest):
     )
 
     # Deploy kubeflow-roles and kubeflow-profiles to create a Profile
-    await ops_test.model.deploy(apps=["kubeflow-roles", "kubeflow-profiles"], status="active", raised_on_blocked=True, timeout=60*10)
-    await ops_test.model.wait_for_idle(status="active", raised_on_blocked=True, raise_on_error=True, timeout=60*10)
+    await ops_test.model.deploy(
+        apps=["kubeflow-roles", "kubeflow-profiles"],
+        status="active",
+        raised_on_blocked=True,
+        timeout=60 * 10,
+    )
+    await ops_test.model.wait_for_idle(
+        status="active", raised_on_blocked=True, raise_on_error=True, timeout=60 * 10
+    )
 
 
 @pytest.mark.parametrize("example", glob.glob("examples/*.yaml"))
 @pytest.mark.abort_on_fail
-async def test_authorization_for_creating_resources(example, ops_test: OpsTest, lightkube_client, apply_profile):
+async def test_authorization_for_creating_resources(
+    example, ops_test: OpsTest, lightkube_client, apply_profile
+):
     """Assert a *Job can be created by a user in the user namespace."""
     # Set up for creating an object of kind *Job
     job_yaml = yaml.safe_load(Path(example).read_text())
     training_job = job_yaml["kind"]
-    _, stdout, __ = await ops_test.run("kubectl", "auth", "can-i", "create", f"{training_job}",  f"--as=system:serviceaccount:{PROFILE_NAMESPACE}:default-editor", f"--namespace={PROFILE_NAMESPACE}", check=True, fail_msg="Failed to execute kubectl auth")
+    _, stdout, __ = await ops_test.run(
+        "kubectl",
+        "auth",
+        "can-i",
+        "create",
+        f"{training_job}",
+        f"--as=system:serviceaccount:{PROFILE_NAMESPACE}:default-editor",
+        f"--namespace={PROFILE_NAMESPACE}",
+        check=True,
+        fail_msg="Failed to execute kubectl auth",
+    )
     assert stdout == "yes"
+
 
 def apply_manifests(lightkube_client: lightkube.Client, yaml_file_path: str):
     """Apply resources using manifest files and returns the applied object.
@@ -70,17 +91,19 @@ def apply_manifests(lightkube_client: lightkube.Client, yaml_file_path: str):
             raise api_error
     return obj
 
+
 @pytest.fixture(scope="module")
 def lightkube_client() -> lightkube.Client:
     """Returns a lightkube Client that can talk to the K8s API."""
     client = lightkube.Client(field_manager="kfp-operators")
     return client
 
+
 @pytest.fixture(scope="module")
 def apply_profile(lightkube_client):
     """Apply a Profile simulating a user."""
     # Create a Viewer namespaced resource
-    profile_class_resource = create_global_resource(
+    profile_class_resource = create_global_resource(  # noqa F841
         group="kubeflow.org", version="v1", kind="Profile", plural="profiles"
     )
 
@@ -101,5 +124,3 @@ def apply_profile(lightkube_client):
             )
         except lightkube.core.exceptions.ApiError as api_error:
             raise api_error
-
-

--- a/tests/integration/test_charm_with_profile.py
+++ b/tests/integration/test_charm_with_profile.py
@@ -37,16 +37,12 @@ async def test_build_and_deploy(ops_test: OpsTest):
     await ops_test.model.deploy(
         entity_url="kubeflow-roles",
         channel="latest/edge",
-        status="active",
-        raised_on_blocked=True,
-        timeout=60 * 10,
+        trust=True,
     )
     await ops_test.model.deploy(
         entity_url="kubeflow-profiles",
         channel="latest/edge",
-        status="active",
-        raised_on_blocked=True,
-        timeout=60 * 10,
+        trust=True,
     )
 
     await ops_test.model.wait_for_idle(

--- a/tests/integration/test_charm_with_profile.py
+++ b/tests/integration/test_charm_with_profile.py
@@ -12,7 +12,7 @@ from lightkube.generic_resource import create_global_resource
 
 basedir = Path("./").absolute()
 PROFILE_NAMESPACE = "profile-example"
-PROFILE_FILE_PATH = f"{basedir}/tests/integration/profile/profile.yaml"
+PROFILE_FILE_PATH = f"{basedir}/tests/integration/profile.yaml"
 PROFILE_FILE = yaml.safe_load(Path(PROFILE_FILE_PATH).read_text())
 KUBEFLOW_USER_NAME = PROFILE_FILE["spec"]["owner"]["name"]
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())

--- a/tests/integration/test_charm_with_profile.py
+++ b/tests/integration/test_charm_with_profile.py
@@ -10,14 +10,7 @@ import yaml
 from lightkube import codecs
 from lightkube.generic_resource import create_global_resource
 from pytest_operator.plugin import OpsTest
-from tenacity import (
-    RetryError,
-    Retrying,
-    retry,
-    stop_after_attempt,
-    stop_after_delay,
-    wait_exponential,
-)
+from tenacity import RetryError, Retrying, stop_after_attempt, stop_after_delay
 
 basedir = Path("./").absolute()
 PROFILE_NAMESPACE = "profile-example"
@@ -113,7 +106,9 @@ def lightkube_client() -> lightkube.Client:
 def apply_profile(lightkube_client):
     """Apply a Profile simulating a user."""
     # Create a Profile global resource
-    profile_resource = create_global_resource(group="kubeflow.org", version="v1", kind="Profile", plural="profiles")
+    profile_resource = create_global_resource(
+        group="kubeflow.org", version="v1", kind="Profile", plural="profiles"
+    )
 
     # Apply Profile first
     apply_manifests(lightkube_client, PROFILE_FILE_PATH)

--- a/tests/integration/test_charm_with_profile.py
+++ b/tests/integration/test_charm_with_profile.py
@@ -1,0 +1,105 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+import glob
+from pathlib import Path
+
+import pytest
+import yaml
+from pytest_operator.plugin import OpsTest
+import lightkube
+from lightkube import codecs
+from lightkube.generic_resource import create_global_resource
+
+basedir = Path("./").absolute()
+PROFILE_NAMESPACE = "profile-example"
+PROFILE_FILE_PATH = f"{basedir}/tests/integration/profile/profile.yaml"
+PROFILE_FILE = yaml.safe_load(Path(PROFILE_FILE_PATH).read_text())
+KUBEFLOW_USER_NAME = PROFILE_FILE["spec"]["owner"]["name"]
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+APP_NAME = "training-operator"
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest):
+    """Build the charm and deploy."""
+    charm_under_test = await ops_test.build_charm(".")
+    image_path = METADATA["resources"]["training-operator-image"]["upstream-source"]
+    resources = {"training-operator-image": image_path}
+
+    await ops_test.model.deploy(
+        charm_under_test, resources=resources, application_name=APP_NAME, trust=True
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=60 * 10
+    )
+
+    # Deploy kubeflow-roles and kubeflow-profiles to create a Profile
+    await ops_test.model.deploy(apps=["kubeflow-roles", "kubeflow-profiles"], status="active", raised_on_blocked=True, timeout=60*10)
+    await ops_test.model.wait_for_idle(status="active", raised_on_blocked=True, raise_on_error=True, timeout=60*10)
+
+
+@pytest.mark.parametrize("example", glob.glob("examples/*.yaml"))
+@pytest.mark.abort_on_fail
+async def test_authorization_for_creating_resources(example, ops_test: OpsTest, lightkube_client, apply_profile):
+    """Assert a *Job can be created by a user in the user namespace."""
+    # Set up for creating an object of kind *Job
+    job_yaml = yaml.safe_load(Path(example).read_text())
+    training_job = job_yaml["kind"]
+    _, stdout, __ = await ops_test.run("kubectl", "auth", "can-i", "create", f"{training_job}",  f"--as=system:serviceaccount:{PROFILE_NAMESPACE}:default-editor", f"--namespace={PROFILE_NAMESPACE}", check=True, fail_msg="Failed to execute kubectl auth")
+    assert stdout == "yes"
+
+def apply_manifests(lightkube_client: lightkube.Client, yaml_file_path: str):
+    """Apply resources using manifest files and returns the applied object.
+
+    Args:
+        lightkube_client (lightkube.Client): an instance of lightkube.Client to
+            use for applying resources.
+        yaml_file_path (str): the resource yaml file.
+
+    Returns:
+        A namespaced or global lightkube resource (obj).
+    """
+    read_yaml = Path(yaml_file_path).read_text()
+    yaml_loaded = codecs.load_all_yaml(read_yaml)
+    for obj in yaml_loaded:
+        try:
+            lightkube_client.apply(
+                obj=obj,
+                name=obj.metadata.name,
+            )
+        except lightkube.core.exceptions.ApiError as api_error:
+            raise api_error
+    return obj
+
+@pytest.fixture(scope="module")
+def lightkube_client() -> lightkube.Client:
+    """Returns a lightkube Client that can talk to the K8s API."""
+    client = lightkube.Client(field_manager="kfp-operators")
+    return client
+
+@pytest.fixture(scope="module")
+def apply_profile(lightkube_client):
+    """Apply a Profile simulating a user."""
+    # Create a Viewer namespaced resource
+    profile_class_resource = create_global_resource(
+        group="kubeflow.org", version="v1", kind="Profile", plural="profiles"
+    )
+
+    # Apply Profile first
+    apply_manifests(lightkube_client, PROFILE_FILE_PATH)
+
+    yield
+
+    # Remove namespace
+    read_yaml = Path(PROFILE_FILE_PATH).read_text()
+    yaml_loaded = codecs.load_all_yaml(read_yaml)
+    for obj in yaml_loaded:
+        try:
+            lightkube_client.delete(
+                res=type(obj),
+                name=obj.metadata.name,
+                namespace=obj.metadata.namespace,
+            )
+        except lightkube.core.exceptions.ApiError as api_error:
+            raise api_error
+
+

--- a/tox.ini
+++ b/tox.ini
@@ -73,8 +73,14 @@ deps =
     -r requirements-unit.txt
 description = Run unit tests
 
-[testenv:integration]
-commands = pytest -v --tb native --asyncio-mode=auto {[vars]tst_path}integration --log-cli-level=INFO -s {posargs}
+[testenv:charm-integration]
+commands = pytest -v --tb native --asyncio-mode=auto {[vars]tst_path}integration/test_charm.py --log-cli-level=INFO -s {posargs}
 deps =
     -r requirements-integration.txt
 description = Run integration tests
+
+[testenv:integration-with-profiles]
+commands = pytest -v --tb native --asyncio-mode=auto {[vars]tst_path}integration/test_charm_with_profile.py --log-cli-level=INFO -s {posargs}
+deps =
+    -r requirements-integration.txt
+description = Run integration tests with profiles

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ max-line-length = 100
 [tox]
 skipsdist = True
 skip_missing_interpreters = True
-envlist = fmt, lint, unit, integration
+envlist = fmt, lint, unit, charm-integration, integration-with-profiles
 
 [vars]
 all_path = {[vars]src_path} {[vars]tst_path}
@@ -74,13 +74,15 @@ deps =
 description = Run unit tests
 
 [testenv:charm-integration]
-commands = pytest -v --tb native --asyncio-mode=auto {[vars]tst_path}integration/test_charm.py --log-cli-level=INFO -s {posargs}
+commands = pytest -v --tb native --asyncio-mode=auto \
+               {[vars]tst_path}integration/test_charm.py --log-cli-level=INFO -s {posargs}
 deps =
     -r requirements-integration.txt
 description = Run integration tests
 
 [testenv:integration-with-profiles]
-commands = pytest -v --tb native --asyncio-mode=auto {[vars]tst_path}integration/test_charm_with_profile.py --log-cli-level=INFO -s {posargs}
+commands = pytest -v --tb native --asyncio-mode=auto \
+               {[vars]tst_path}integration/test_charm_with_profile.py --log-cli-level=INFO -s {posargs}
 deps =
     -r requirements-integration.txt
 description = Run integration tests with profiles


### PR DESCRIPTION
Adds Aggregation ClusterRoles for training-operators so the `default-editor` can get access to manage the various *Jobs the training-operator offers. This fixes #108 in `main`, thus `latest/edge`, a follow up PR will be sent to fix the issue in the `1.7/stable` channel.

Part of #108

TODO:
- [x] Add an integration test case for covering the scenario described in #108 