### PR TITLE
fix: Pin Prometheus and Grafana revisions (#128)

### DIFF
--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -136,8 +136,28 @@ async def test_prometheus_grafana_integration(ops_test: OpsTest):
     scrape_config = {"scrape_interval": "30s"}
 
     # Deploy and relate prometheus
-    await ops_test.model.deploy(prometheus, channel="latest/edge", trust=True)
-    await ops_test.model.deploy(grafana, channel="latest/edge", trust=True)
+    # FIXME: Unpin revision once https://github.com/canonical/bundle-kubeflow/issues/688 is closed
+    await ops_test.juju(
+        "deploy",
+        prometheus,
+        "--channel",
+        "latest/edge",
+        "--revision",
+        "137",
+        "--trust",
+        check=True,
+    )
+    # FIXME: Unpin revision once https://github.com/canonical/bundle-kubeflow/issues/690 is closed
+    await ops_test.juju(
+        "deploy",
+        grafana,
+        "--channel",
+        "latest/edge",
+        "--revision",
+        "89",
+        "--trust",
+        check=True,
+    )
     await ops_test.model.deploy(prometheus_scrape, channel="latest/beta", config=scrape_config)
 
     await ops_test.model.add_relation(APP_NAME, prometheus_scrape)


### PR DESCRIPTION
This is a temporary patch until we migrate to Juju 3.1:
* Pin Prometheus revision when deploying from `latest` to avoid fetching recent patches of the charm which assume `juju >= 3.0.3`. Revision 137 was the last one seen working properly in our [CI integration tests](https://github.com/canonical/notebook-operators/actions/runs/5904696558/job/16017327250#step:4:212).
* Pin Grafana revision when deploying from `latest` to avoid fetching recent patches of the charm which fail to install on Juju 2.9. Revision 89 was the last one working properly in our CI integration tests.

Refs https://github.com/canonical/bundle-kubeflow/issues/688
Refs https://github.com/canonical/bundle-kubeflow/issues/690