### PR TITLE
refactor: deploy the training-operator with kubernetes resources

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -12,4 +12,3 @@ bases:
 parts:
   charm:
     charm-python-packages: [setuptools, pip]
-    build-packages: [git, vim]

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -12,4 +12,4 @@ bases:
 parts:
   charm:
     charm-python-packages: [setuptools, pip]
-    build-packages: [git]
+    build-packages: [git, vim]

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,6 @@
+options:
+  training-operator-image:
+    default: kubeflow/training-operator:v1-855e096
+    description: |
+      Container image to be used by the training-operator workload.
+    type: string

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -8,14 +8,6 @@ description: |
   This charm deploys the Operator configured for use with Kubeflow to
   Kubernetes models in Juju.
 docs: https://discourse.charmhub.io/t/8241
-containers:
-  training-operator:
-    resource: training-operator-image
-resources:
-  training-operator-image:
-    type: oci-image
-    description: OCI image for training-operator
-    upstream-source: kubeflow/training-operator:v1-855e096
 provides:
   metrics-endpoint:
     interface: prometheus_scrape

--- a/src/charm.py
+++ b/src/charm.py
@@ -116,7 +116,6 @@ class TrainingOperatorCharm(CharmBase):
 
     def _check_leader(self):
         """Check if this unit is a leader."""
-        self.framework.observe(self.on.update_status, self._on_event)
         if not self.unit.is_leader():
             self.logger.info("Not a leader, skipping setup")
             raise ErrorWithStatus("Waiting for leadership", WaitingStatus)

--- a/src/charm.py
+++ b/src/charm.py
@@ -73,7 +73,9 @@ class TrainingOperatorCharm(CharmBase):
             jobs=[
                 {
                     "metrics_path": METRICS_PATH,
-                    "static_configs": [{"targets": [f"{self._name}.{self._namespace}.svc:{METRICS_PORT}"]}],
+                    "static_configs": [
+                        {"targets": [f"{self._name}.{self._namespace}.svc:{METRICS_PORT}"]}
+                    ],
                 }
             ],
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -38,24 +38,6 @@ class TrainingOperatorCharm(CharmBase):
         super().__init__(*args)
 
         self.logger = logging.getLogger(__name__)
-        metrics_port = ServicePort(int(METRICS_PORT), name="metrics-port")
-        self.service_patcher = KubernetesServicePatch(
-            self,
-            [metrics_port],
-            service_name=f"{self.model.app.name}",
-        )
-
-        self.prometheus_provider = MetricsEndpointProvider(
-            charm=self,
-            relation_name="metrics-endpoint",
-            jobs=[
-                {
-                    "metrics_path": METRICS_PATH,
-                    "static_configs": [{"targets": ["*:{}".format(METRICS_PORT)]}],
-                }
-            ],
-        )
-
         self._image = self.config["training-operator-image"]
         self._name = self.model.app.name
         self._namespace = self.model.name
@@ -77,6 +59,24 @@ class TrainingOperatorCharm(CharmBase):
         self.framework.observe(self.on.leader_elected, self._on_event)
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.remove, self._on_remove)
+
+        metrics_port = ServicePort(int(METRICS_PORT), name="metrics-port")
+        self.service_patcher = KubernetesServicePatch(
+            self,
+            [metrics_port],
+            service_name=f"{self.model.app.name}",
+        )
+
+        self.prometheus_provider = MetricsEndpointProvider(
+            charm=self,
+            relation_name="metrics-endpoint",
+            jobs=[
+                {
+                    "metrics_path": METRICS_PATH,
+                    "static_configs": [{"targets": [f"{self._name}.{self._namespace}.svc:{METRICS_PORT}"]}],
+                }
+            ],
+        )
 
     @property
     def k8s_resource_handler(self):

--- a/src/templates/deployment.yaml.j2
+++ b/src/templates/deployment.yaml.j2
@@ -16,6 +16,8 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         control-plane: {{ namespace }}-{{ app_name }}
+        # Use this label so the training operator Pod can use the juju created Service
+        app.kubernetes.io/name: {{ app_name }}
     spec:
       containers:
       - command:

--- a/src/templates/deployment.yaml.j2
+++ b/src/templates/deployment.yaml.j2
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: {{ namespace }}-{{ app_name }}
+  name: {{ app_name }}
+  namespace: {{ namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: {{ namespace }}-{{ app_name }}
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        control-plane: {{ namespace }}-{{ app_name }}
+    spec:
+      containers:
+      - command:
+        - /manager
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: {{ training_operator_image }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 3
+        name: {{ app_name }}
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 15
+          timeoutSeconds: 3
+        securityContext:
+          allowPrivilegeEscalation: false
+      serviceAccountName: {{ app_name }}-workload
+      terminationGracePeriodSeconds: 10

--- a/src/templates/rbac_manifests.yaml.j2
+++ b/src/templates/rbac_manifests.yaml.j2
@@ -306,6 +306,87 @@ rules:
       - update
       - watch
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-training-admin
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.authorization.kubeflow.org/aggregate-to-kubeflow-training-admin: "true"
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-training-edit
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-training-admin: "true"
+rules:
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - mpijobs
+      - tfjobs
+      - pytorchjobs
+      - mxjobs
+      - xgboostjobs
+      - paddlejobs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - mpijobs/status
+      - tfjobs/status
+      - pytorchjobs/status
+      - mxjobs/status
+      - xgboostjobs/status
+      - paddlejobs/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-training-view
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+rules:
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - mpijobs
+      - tfjobs
+      - pytorchjobs
+      - mxjobs
+      - xgboostjobs
+      - paddlejobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - mpijobs/status
+      - tfjobs/status
+      - pytorchjobs/status
+      - mxjobs/status
+      - xgboostjobs/status
+      - paddlejobs/status
+    verbs:
+      - get
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/src/templates/rbac_manifests.yaml.j2
+++ b/src/templates/rbac_manifests.yaml.j2
@@ -1,9 +1,23 @@
-# Source: manifests/base/cluster-role.yaml
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ app_name }}
+  name: {{ app_name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: training-operator
+subjects:
+  - kind: ServiceAccount
+    name: {{ app_name }}-workload
+    namespace: {{ namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ namespace }}-{{ app_name }}-charm
+  name: {{ app_name }}
 rules:
   - apiGroups:
       - ""
@@ -47,6 +61,15 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
       - serviceaccounts
     verbs:
       - create
@@ -62,6 +85,15 @@ rules:
       - delete
       - get
       - list
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - update
       - watch
   - apiGroups:
       - autoscaling
@@ -174,7 +206,7 @@ rules:
   - apiGroups:
       - kubeflow.org
     resources:
-     - pytorchjobs/status
+      - pytorchjobs/status
     verbs:
       - get
       - patch
@@ -205,7 +237,6 @@ rules:
       - get
       - patch
       - update
-  # This is needed for the launcher role of the MPI operator.
   - apiGroups:
       - kubeflow.org
     resources:
@@ -274,85 +305,11 @@ rules:
       - patch
       - update
       - watch
-# Source manifests/apps/training-operator/upstream/overlays/kubeflow/kubeflow-training-roles.yaml
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+apiVersion: v1
+kind: ServiceAccount
 metadata:
-  name: kubeflow-training-admin
   labels:
-    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
-aggregationRule:
-  clusterRoleSelectors:
-    - matchLabels:
-        rbac.authorization.kubeflow.org/aggregate-to-kubeflow-training-admin: "true"
-rules: []
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: kubeflow-training-edit
-  labels:
-    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
-    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-training-admin: "true"
-rules:
-  - apiGroups:
-      - kubeflow.org
-    resources:
-      - mpijobs
-      - tfjobs
-      - pytorchjobs
-      - mxjobs
-      - xgboostjobs
-      - paddlejobs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kubeflow.org
-    resources:
-      - mpijobs/status
-      - tfjobs/status
-      - pytorchjobs/status
-      - mxjobs/status
-      - xgboostjobs/status
-      - paddlejobs/status
-    verbs:
-      - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: kubeflow-training-view
-  labels:
-    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
-rules:
-  - apiGroups:
-      - kubeflow.org
-    resources:
-      - mpijobs
-      - tfjobs
-      - pytorchjobs
-      - mxjobs
-      - xgboostjobs
-      - paddlejobs
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - kubeflow.org
-    resources:
-      - mpijobs/status
-      - tfjobs/status
-      - pytorchjobs/status
-      - mxjobs/status
-      - xgboostjobs/status
-      - paddlejobs/status
-    verbs:
-      - get
+    app: {{ app_name }}-workload
+  name: {{ app_name }}-workload
+  namespace: {{ namespace }}

--- a/src/templates/rbac_manifests.yaml.j2
+++ b/src/templates/rbac_manifests.yaml.j2
@@ -8,7 +8,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: training-operator
+  name: {{ app_name }}
 subjects:
   - kind: ServiceAccount
     name: {{ app_name }}-workload

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -19,7 +19,6 @@ from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = "training-operator"
 CHARM_LOCATION = None
 
@@ -31,11 +30,9 @@ async def test_build_and_deploy(ops_test: OpsTest):
     Assert on the unit status.
     """
     charm_under_test = await ops_test.build_charm(".")
-    image_path = METADATA["resources"]["training-operator-image"]["upstream-source"]
-    resources = {"training-operator-image": image_path}
 
     await ops_test.model.deploy(
-        charm_under_test, resources=resources, application_name=APP_NAME, trust=True
+        charm_under_test, application_name=APP_NAME, trust=True
     )
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=60 * 10
@@ -252,12 +249,10 @@ async def test_upgrade(ops_test: OpsTest):
 
     # refresh (upgrade) using charm built in test_build_and_deploy()
     # NOTE: using ops_test.juju() because there is no functionality to refresh in ops_test
-    image_path = METADATA["resources"]["training-operator-image"]["upstream-source"]
     await ops_test.juju(
         "refresh",
         APP_NAME,
         f"--path={CHARM_LOCATION}",
-        f'--resource="training-operator-image={image_path}"',
         "--trust",
     )
     await ops_test.model.wait_for_idle(

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -29,7 +29,6 @@ APP_PREVIOUS_CHANNEL = "1.7/stable"
 METRICS_PATH = "/metrics"
 METRICS_PORT = 8080
 
-
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest):
     """Build the charm and deploy it with trust=True.
@@ -149,7 +148,8 @@ async def test_metrics_enpoint(ops_test: OpsTest):
     ones provided to the function.
     """
     app = ops_test.model.applications[APP_NAME]
-    await assert_metrics_endpoint(app, metrics_port=METRICS_PORT, metrics_path=METRICS_PATH)
+    metrics_target = f"{APP_NAME}.{ops_test.model.name}.svc"
+    await assert_metrics_endpoint(app, metrics_port=METRICS_PORT, metrics_path=METRICS_PATH, metrics_target=metrics_target)
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -31,9 +31,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     """
     charm_under_test = await ops_test.build_charm(".")
 
-    await ops_test.model.deploy(
-        charm_under_test, application_name=APP_NAME, trust=True
-    )
+    await ops_test.model.deploy(charm_under_test, application_name=APP_NAME, trust=True)
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=60 * 10
     )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -29,6 +29,7 @@ APP_PREVIOUS_CHANNEL = "1.7/stable"
 METRICS_PATH = "/metrics"
 METRICS_PORT = 8080
 
+
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest):
     """Build the charm and deploy it with trust=True.
@@ -148,8 +149,13 @@ async def test_metrics_enpoint(ops_test: OpsTest):
     ones provided to the function.
     """
     app = ops_test.model.applications[APP_NAME]
+    # metrics_target should be the same as the one defined in the charm code when instantiating
+    # the MetricsEndpointProvider. It is set to the training-operator Service name because this
+    # charm is not a sidecar, once this is re-written in sidecar pattern, this value can be *
     metrics_target = f"{APP_NAME}.{ops_test.model.name}.svc"
-    await assert_metrics_endpoint(app, metrics_port=METRICS_PORT, metrics_path=METRICS_PATH, metrics_target=metrics_target)
+    await assert_metrics_endpoint(
+        app, metrics_port=METRICS_PORT, metrics_path=METRICS_PATH, metrics_target=metrics_target
+    )
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_charm_with_profile.py
+++ b/tests/integration/test_charm_with_profile.py
@@ -37,9 +37,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     """Build the charm and deploy."""
     charm_under_test = await ops_test.build_charm(".")
 
-    await ops_test.model.deploy(
-        charm_under_test, application_name=APP_NAME, trust=True
-    )
+    await ops_test.model.deploy(charm_under_test, application_name=APP_NAME, trust=True)
 
     # Deploy kubeflow-roles and kubeflow-profiles to create a Profile
     await ops_test.model.deploy(

--- a/tests/integration/test_charm_with_profile.py
+++ b/tests/integration/test_charm_with_profile.py
@@ -27,7 +27,6 @@ PROFILE_NAMESPACE = "profile-example"
 PROFILE_NAME = "profile-example"
 PROFILE_FILE_PATH = basedir / "tests/integration/profile.yaml"
 PROFILE_FILE = yaml.safe_load(PROFILE_FILE_PATH.read_text())
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = "training-operator"
 
 log = logging.getLogger(__name__)
@@ -37,11 +36,9 @@ log = logging.getLogger(__name__)
 async def test_build_and_deploy(ops_test: OpsTest):
     """Build the charm and deploy."""
     charm_under_test = await ops_test.build_charm(".")
-    image_path = METADATA["resources"]["training-operator-image"]["upstream-source"]
-    resources = {"training-operator-image": image_path}
 
     await ops_test.model.deploy(
-        charm_under_test, resources=resources, application_name=APP_NAME, trust=True
+        charm_under_test, application_name=APP_NAME, trust=True
     )
 
     # Deploy kubeflow-roles and kubeflow-profiles to create a Profile

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -42,9 +42,6 @@ def harness() -> Harness:
     """Create and return Harness for testing."""
     harness = Harness(TrainingOperatorCharm)
 
-    # setup container networking simulation
-    harness.set_can_connect("training-operator", True)
-
     return harness
 
 
@@ -62,7 +59,6 @@ class TestCharm:
     ):
         """Test not a leader scenario."""
         harness.begin_with_initial_hooks()
-        harness.container_pebble_ready("training-operator")
         assert harness.charm.model.unit.status == WaitingStatus("Waiting for leadership")
 
     @patch("charm.TrainingOperatorCharm.k8s_resource_handler")
@@ -76,41 +72,9 @@ class TestCharm:
     ):
         """Test no relation scenario."""
         harness.set_leader(True)
-        harness.add_oci_resource(
-            "training-operator-image",
-            {
-                "registrypath": "ci-test",
-                "username": "",
-                "password": "",
-            },
-        )
 
         harness.begin_with_initial_hooks()
-        harness.container_pebble_ready("training-operator")
         assert harness.charm.model.unit.status == ActiveStatus("")
-
-    @patch("charm.TrainingOperatorCharm.k8s_resource_handler")
-    @patch("charm.TrainingOperatorCharm.crd_resource_handler")
-    @patch("charm.KubernetesServicePatch", lambda *_, **__: None)
-    def test_pebble_layer(
-        self,
-        _: MagicMock,  # k8s_resource_handler
-        ___: MagicMock,  # crd_resource_handler
-        harness: Harness,
-    ):
-        """Test creation of Pebble layer. Only testing specific items."""
-        harness.set_leader(True)
-        harness.set_model_name("test_kubeflow")
-        harness.begin_with_initial_hooks()
-        harness.container_pebble_ready("training-operator")
-        pebble_plan = harness.get_container_pebble_plan("training-operator")
-        assert pebble_plan
-        assert pebble_plan._services
-        pebble_plan_info = pebble_plan.to_dict()
-        assert pebble_plan_info["services"]["training-operator"]["command"] == "/manager"
-        test_env = pebble_plan_info["services"]["training-operator"]["environment"]
-        assert 2 == len(test_env)
-        assert "test_kubeflow" == test_env["MY_POD_NAMESPACE"]
 
     @patch("charm.TrainingOperatorCharm.k8s_resource_handler")
     @patch("charm.TrainingOperatorCharm.crd_resource_handler")


### PR DESCRIPTION
This commit refactors the way the training-operator is deployed, as instead of using a sidecar container that runs the workload, we are now applying the Deployment and all the Kubernetes resources required by the training-operator controller to be able to mange training resources.
We are introducing this change in preparation for the upcoming 1.8 version, as it introduces the hard dependency on a Kubernetes Secret mounted in a volume for the training-operator workload to start. For more details please refer to canonical/training-operator#159.