### PR TITLE
pin integration test dependencies, refactor constants in tests (#155)

### DIFF
--- a/requirements-integration.in
+++ b/requirements-integration.in
@@ -1,3 +1,5 @@
+# This is required due to the abstraction of cos integration
+charmed-kubeflow-chisme>=0.4.0
 # Pinning to <4.0 due to compatibility with the 3.1 controller version
 juju<4.0
 lightkube

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -8,6 +8,8 @@ anyio==4.0.0
     # via httpcore
 asttokens==2.4.0
     # via stack-data
+attrs==23.2.0
+    # via jsonschema
 backcall==0.2.0
     # via ipython
 bcrypt==4.0.1
@@ -24,6 +26,8 @@ cffi==1.15.1
     # via
     #   cryptography
     #   pynacl
+charmed-kubeflow-chisme==0.4.0
+    # via -r requirements-integration.in
 charset-normalizer==3.2.0
     # via requests
 cryptography==41.0.3
@@ -32,6 +36,8 @@ decorator==5.1.1
     # via
     #   ipdb
     #   ipython
+deepdiff==6.2.1
+    # via charmed-kubeflow-chisme
 exceptiongroup==1.1.3
     # via
     #   anyio
@@ -53,6 +59,8 @@ idna==3.4
     #   anyio
     #   httpx
     #   requests
+importlib-resources==6.4.0
+    # via jsonschema
 iniconfig==2.0.0
     # via pytest
 ipdb==0.13.13
@@ -62,15 +70,22 @@ ipython==8.12.2
 jedi==0.19.0
     # via ipython
 jinja2==3.1.2
-    # via pytest-operator
+    # via
+    #   charmed-kubeflow-chisme
+    #   pytest-operator
+jsonschema==4.17.3
+    # via serialized-data-interface
 juju==3.2.2
     # via
     #   -r requirements-integration.in
+    #   charmed-kubeflow-chisme
     #   pytest-operator
 kubernetes==27.2.0
     # via juju
 lightkube==0.14.0
-    # via -r requirements-integration.in
+    # via
+    #   -r requirements-integration.in
+    #   charmed-kubeflow-chisme
 lightkube-models==1.28.1.4
     # via lightkube
 macaroonbakery==1.3.1
@@ -85,6 +100,12 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
+ops==2.14.0
+    # via
+    #   charmed-kubeflow-chisme
+    #   serialized-data-interface
+ordered-set==4.1.0
+    # via deepdiff
 packaging==23.1
     # via pytest
 paramiko==2.12.0
@@ -95,6 +116,8 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
+pkgutil-resolve-name==1.3.10
+    # via jsonschema
 pluggy==1.3.0
     # via pytest
 prompt-toolkit==3.0.39
@@ -129,6 +152,8 @@ pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
+pyrsistent==0.20.0
+    # via jsonschema
 pytest==7.4.2
     # via
     #   -r requirements-integration.in
@@ -148,7 +173,9 @@ pyyaml==6.0.1
     #   juju
     #   kubernetes
     #   lightkube
+    #   ops
     #   pytest-operator
+    #   serialized-data-interface
 requests==2.31.0
     # via
     #   -r requirements-integration.in
@@ -156,10 +183,17 @@ requests==2.31.0
     #   kubernetes
     #   macaroonbakery
     #   requests-oauthlib
+    #   serialized-data-interface
 requests-oauthlib==1.3.1
     # via kubernetes
 rsa==4.9
     # via google-auth
+ruamel-yaml==0.18.6
+    # via charmed-kubeflow-chisme
+ruamel-yaml-clib==0.2.8
+    # via ruamel-yaml
+serialized-data-interface==0.7.0
+    # via charmed-kubeflow-chisme
 six==1.16.0
     # via
     #   asttokens
@@ -177,7 +211,9 @@ sniffio==1.3.0
 stack-data==0.6.2
     # via ipython
 tenacity==8.2.3
-    # via -r requirements-integration.in
+    # via
+    #   -r requirements-integration.in
+    #   charmed-kubeflow-chisme
 tomli==2.0.1
     # via
     #   ipdb
@@ -202,6 +238,10 @@ urllib3==1.26.16
 wcwidth==0.2.6
     # via prompt-toolkit
 websocket-client==1.6.2
-    # via kubernetes
+    # via
+    #   kubernetes
+    #   ops
 websockets==8.1
     # via juju
+zipp==3.19.2
+    # via importlib-resources

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -143,8 +143,7 @@ async def test_alert_rules(ops_test: OpsTest):
     app = ops_test.model.applications[APP_NAME]
     alert_rules = get_alert_rules()
     logger.info("found alert_rules: %s", alert_rules)
-    for attempt in retry_for_5_attempts:
-        await assert_alert_rules(app, alert_rules)
+    await assert_alert_rules(app, alert_rules)
 
 
 async def test_metrics_enpoint(ops_test: OpsTest):
@@ -155,16 +154,7 @@ async def test_metrics_enpoint(ops_test: OpsTest):
     ones provided to the function.
     """
     app = ops_test.model.applications[APP_NAME]
-    for attempt in retry_for_5_attempts:
-        await assert_metrics_endpoint(app, metrics_port=METRICS_PORT, metrics_path=METRICS_PATH)
-
-
-# Helper to retry calling a function over 30 seconds or 5 attempts
-retry_for_5_attempts = tenacity.Retrying(
-    stop=(tenacity.stop_after_attempt(5) | tenacity.stop_after_delay(30)),
-    wait=tenacity.wait_exponential(multiplier=1, min=1, max=10),
-    reraise=True,
-)
+    await assert_metrics_endpoint(app, metrics_port=METRICS_PORT, metrics_path=METRICS_PATH)
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -22,6 +22,17 @@ logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = "training-operator"
 CHARM_LOCATION = None
+APP_PREVIOUS_CHANNEL = "1.7/stable"
+
+PROMETHEUS_K8S = "prometheus-k8s"
+PROMETHEUS_K8S_CHANNEL = "latest/stable"
+PROMETHEUS_K8S_TRUST = True
+GRAFANA_K8S = "grafana-k8s"
+GRAFANA_K8S_CHANNEL = "latest/stable"
+GRAFANA_K8S_TRUST = True
+PROMETHEUS_SCRAPE_K8S = "prometheus-scrape-config-k8s"
+PROMETHEUS_SCRAPE_K8S_CHANNEL = "latest/stable"
+PROMETHEUS_SCRAPE_CONFIG = {"scrape_interval": "30s"}
 
 
 @pytest.mark.abort_on_fail
@@ -130,51 +141,43 @@ def test_create_training_jobs(ops_test: OpsTest, example: str):
 
 async def test_prometheus_grafana_integration(ops_test: OpsTest):
     """Deploy prometheus, grafana and required relations, then test the metrics."""
-    prometheus = "prometheus-k8s"
-    grafana = "grafana-k8s"
-    prometheus_scrape = "prometheus-scrape-config-k8s"
-    scrape_config = {"scrape_interval": "30s"}
-
     # Deploy and relate prometheus
-    # FIXME: Unpin revision once https://github.com/canonical/bundle-kubeflow/issues/688 is closed
-    await ops_test.juju(
-        "deploy",
-        prometheus,
-        "--channel",
-        "latest/edge",
-        "--revision",
-        "137",
-        "--trust",
-        check=True,
-    )
-    # FIXME: Unpin revision once https://github.com/canonical/bundle-kubeflow/issues/690 is closed
-    await ops_test.juju(
-        "deploy",
-        grafana,
-        "--channel",
-        "latest/edge",
-        "--revision",
-        "89",
-        "--trust",
-        check=True,
-    )
-    await ops_test.model.deploy(prometheus_scrape, channel="latest/beta", config=scrape_config)
-
-    await ops_test.model.add_relation(APP_NAME, prometheus_scrape)
-    await ops_test.model.add_relation(
-        f"{prometheus}:grafana-dashboard", f"{grafana}:grafana-dashboard"
-    )
-    await ops_test.model.add_relation(
-        f"{APP_NAME}:grafana-dashboard", f"{grafana}:grafana-dashboard"
-    )
-    await ops_test.model.add_relation(
-        f"{prometheus}:metrics-endpoint", f"{prometheus_scrape}:metrics-endpoint"
+    await ops_test.model.deploy(
+        PROMETHEUS_K8S,
+        channel=PROMETHEUS_K8S_CHANNEL,
+        trust=PROMETHEUS_K8S_TRUST,
     )
 
+    await ops_test.model.deploy(
+        GRAFANA_K8S,
+        channel=GRAFANA_K8S_CHANNEL,
+        trust=GRAFANA_K8S_TRUST,
+    )
+
+    await ops_test.model.deploy(
+        PROMETHEUS_SCRAPE_K8S,
+        channel=PROMETHEUS_SCRAPE_K8S_CHANNEL,
+        config=PROMETHEUS_SCRAPE_CONFIG,
+    )
+
+    await ops_test.model.add_relation(APP_NAME, PROMETHEUS_SCRAPE_K8S)
+    await ops_test.model.add_relation(
+        f"{PROMETHEUS_K8S}:grafana-dashboard",
+        f"{GRAFANA_K8S}:grafana-dashboard",
+    )
+    await ops_test.model.add_relation(
+        f"{APP_NAME}:grafana-dashboard", f"{GRAFANA_K8S}:grafana-dashboard"
+    )
+    await ops_test.model.add_relation(
+        f"{PROMETHEUS_K8S}:metrics-endpoint",
+        f"{PROMETHEUS_SCRAPE_K8S}:metrics-endpoint",
+    )
     await ops_test.model.wait_for_idle(status="active", timeout=60 * 20)
 
     status = await ops_test.model.get_status()
-    prometheus_unit_ip = status["applications"][prometheus]["units"][f"{prometheus}/0"]["address"]
+    prometheus_unit_ip = status["applications"][PROMETHEUS_K8S]["units"][f"{PROMETHEUS_K8S}/0"][
+        "address"
+    ]
     logger.info(f"Prometheus available at http://{prometheus_unit_ip}:9090")
 
     for attempt in retry_for_5_attempts:
@@ -245,7 +248,7 @@ async def test_upgrade(ops_test: OpsTest):
     """
 
     # deploy stable version of the charm
-    await ops_test.model.deploy(entity_url=APP_NAME, channel="1.5/stable", trust=True)
+    await ops_test.model.deploy(entity_url=APP_NAME, channel=APP_PREVIOUS_CHANNEL, trust=True)
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=60 * 10
     )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -21,14 +21,14 @@ from lightkube.resources.apiextensions_v1 import CustomResourceDefinition
 from lightkube.resources.rbac_authorization_v1 import ClusterRole
 from pytest_operator.plugin import OpsTest
 
-from charm import METRICS_PATH, METRICS_PORT
-
 logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = "training-operator"
 CHARM_LOCATION = None
 APP_PREVIOUS_CHANNEL = "1.7/stable"
+METRICS_PATH = "/metrics"
+METRICS_PORT = 8080
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 
 import glob
-import json
 import logging
 from pathlib import Path
 
@@ -10,12 +9,9 @@ import lightkube
 import lightkube.codecs
 import lightkube.generic_resource
 import pytest
-import requests
 import tenacity
 import yaml
-from charm import METRICS_PATH, METRICS_PORT
 from charmed_kubeflow_chisme.testing import (
-    GRAFANA_AGENT_APP,
     assert_alert_rules,
     assert_metrics_endpoint,
     deploy_and_assert_grafana_agent,
@@ -24,6 +20,8 @@ from charmed_kubeflow_chisme.testing import (
 from lightkube.resources.apiextensions_v1 import CustomResourceDefinition
 from lightkube.resources.rbac_authorization_v1 import ClusterRole
 from pytest_operator.plugin import OpsTest
+
+from charm import METRICS_PATH, METRICS_PORT
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +52,9 @@ async def test_build_and_deploy(ops_test: OpsTest):
     # store charm location in global to be used in other tests
     global CHARM_LOCATION
     CHARM_LOCATION = charm_under_test
+
+    # Deploy grafana-agent for COS integration tests
+    await deploy_and_assert_grafana_agent(ops_test.model, APP_NAME, metrics=True)
 
 
 def lightkube_create_global_resources() -> dict:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -13,6 +13,14 @@ import pytest
 import requests
 import tenacity
 import yaml
+from charm import METRICS_PATH, METRICS_PORT
+from charmed_kubeflow_chisme.testing import (
+    GRAFANA_AGENT_APP,
+    assert_alert_rules,
+    assert_metrics_endpoint,
+    deploy_and_assert_grafana_agent,
+    get_alert_rules,
+)
 from lightkube.resources.apiextensions_v1 import CustomResourceDefinition
 from lightkube.resources.rbac_authorization_v1 import ClusterRole
 from pytest_operator.plugin import OpsTest
@@ -23,16 +31,6 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = "training-operator"
 CHARM_LOCATION = None
 APP_PREVIOUS_CHANNEL = "1.7/stable"
-
-PROMETHEUS_K8S = "prometheus-k8s"
-PROMETHEUS_K8S_CHANNEL = "latest/stable"
-PROMETHEUS_K8S_TRUST = True
-GRAFANA_K8S = "grafana-k8s"
-GRAFANA_K8S_CHANNEL = "latest/stable"
-GRAFANA_K8S_TRUST = True
-PROMETHEUS_SCRAPE_K8S = "prometheus-scrape-config-k8s"
-PROMETHEUS_SCRAPE_K8S_CHANNEL = "latest/stable"
-PROMETHEUS_SCRAPE_CONFIG = {"scrape_interval": "30s"}
 
 
 @pytest.mark.abort_on_fail
@@ -139,70 +137,25 @@ def test_create_training_jobs(ops_test: OpsTest, example: str):
     assert_job_status_running_success()
 
 
-async def test_prometheus_grafana_integration(ops_test: OpsTest):
-    """Deploy prometheus, grafana and required relations, then test the metrics."""
-    # Deploy and relate prometheus
-    await ops_test.model.deploy(
-        PROMETHEUS_K8S,
-        channel=PROMETHEUS_K8S_CHANNEL,
-        trust=PROMETHEUS_K8S_TRUST,
-    )
-
-    await ops_test.model.deploy(
-        GRAFANA_K8S,
-        channel=GRAFANA_K8S_CHANNEL,
-        trust=GRAFANA_K8S_TRUST,
-    )
-
-    await ops_test.model.deploy(
-        PROMETHEUS_SCRAPE_K8S,
-        channel=PROMETHEUS_SCRAPE_K8S_CHANNEL,
-        config=PROMETHEUS_SCRAPE_CONFIG,
-    )
-
-    await ops_test.model.add_relation(APP_NAME, PROMETHEUS_SCRAPE_K8S)
-    await ops_test.model.add_relation(
-        f"{PROMETHEUS_K8S}:grafana-dashboard",
-        f"{GRAFANA_K8S}:grafana-dashboard",
-    )
-    await ops_test.model.add_relation(
-        f"{APP_NAME}:grafana-dashboard", f"{GRAFANA_K8S}:grafana-dashboard"
-    )
-    await ops_test.model.add_relation(
-        f"{PROMETHEUS_K8S}:metrics-endpoint",
-        f"{PROMETHEUS_SCRAPE_K8S}:metrics-endpoint",
-    )
-    await ops_test.model.wait_for_idle(status="active", timeout=60 * 20)
-
-    status = await ops_test.model.get_status()
-    prometheus_unit_ip = status["applications"][PROMETHEUS_K8S]["units"][f"{PROMETHEUS_K8S}/0"][
-        "address"
-    ]
-    logger.info(f"Prometheus available at http://{prometheus_unit_ip}:9090")
-
+async def test_alert_rules(self, ops_test: OpsTest):
+    """Test check charm alert rules and rules defined in relation data bag."""
+    app = ops_test.model.applications[APP_NAME]
+    alert_rules = get_alert_rules()
+    logger.info("found alert_rules: %s", alert_rules)
     for attempt in retry_for_5_attempts:
-        logger.info(
-            f"Testing prometheus deployment (attempt " f"{attempt.retry_state.attempt_number})"
-        )
-        with attempt:
-            r = requests.get(
-                f"http://{prometheus_unit_ip}:9090/api/v1/query?"
-                f'query=up{{juju_application="{APP_NAME}"}}'
-            )
-            response = json.loads(r.content.decode("utf-8"))
-            response_status = response["status"]
-            logger.info(f"Response status is {response_status}")
-            assert response_status == "success"
+        await assert_alert_rules(app, alert_rules)
 
-            # Assert the unit is available by checking the query result
-            # The data is presented as a list [1707357912.349, '1'], where the
-            # first value is a timestamp and the second value is the state of the unit
-            # 1 means available, 0 means unavailable
-            assert response["data"]["result"][0]["value"][1] == "1"
 
-            response_metric = response["data"]["result"][0]["metric"]
-            assert response_metric["juju_application"] == APP_NAME
-            assert response_metric["juju_model"] == ops_test.model_name
+async def test_metrics_enpoint(self, ops_test: OpsTest):
+    """Test metrics_endpoints are defined in relation data bag and their accessibility.
+
+    This function gets all the metrics_endpoints from the relation data bag, checks if
+    they are available from the grafana-agent-k8s charm and finally compares them with the
+    ones provided to the function.
+    """
+    app = ops_test.model.applications[APP_NAME]
+    for attempt in retry_for_5_attempts:
+        await assert_metrics_endpoint(app, metrics_port=METRICS_PORT, metrics_path=METRICS_PATH)
 
 
 # Helper to retry calling a function over 30 seconds or 5 attempts

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -138,7 +138,7 @@ def test_create_training_jobs(ops_test: OpsTest, example: str):
     assert_job_status_running_success()
 
 
-async def test_alert_rules(self, ops_test: OpsTest):
+async def test_alert_rules(ops_test: OpsTest):
     """Test check charm alert rules and rules defined in relation data bag."""
     app = ops_test.model.applications[APP_NAME]
     alert_rules = get_alert_rules()
@@ -147,7 +147,7 @@ async def test_alert_rules(self, ops_test: OpsTest):
         await assert_alert_rules(app, alert_rules)
 
 
-async def test_metrics_enpoint(self, ops_test: OpsTest):
+async def test_metrics_enpoint(ops_test: OpsTest):
     """Test metrics_endpoints are defined in relation data bag and their accessibility.
 
     This function gets all the metrics_endpoints from the relation data bag, checks if

--- a/tests/integration/test_charm_with_profile.py
+++ b/tests/integration/test_charm_with_profile.py
@@ -30,6 +30,13 @@ PROFILE_FILE = yaml.safe_load(PROFILE_FILE_PATH.read_text())
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = "training-operator"
 
+KUBEFLOW_ROLES = "kubeflow-roles"
+KUBEFLOW_ROLES_CHANNEL = "latest/edge"
+KUBEFLOW_ROLES_TRUST = True
+KUBEFLOW_PROFILES = "kubeflow-profiles"
+KUBEFLOW_PROFILES_CHANNEL = "latest/edge"
+KUBEFLOW_PROFILES_TRUST = True
+
 log = logging.getLogger(__name__)
 
 
@@ -46,14 +53,14 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     # Deploy kubeflow-roles and kubeflow-profiles to create a Profile
     await ops_test.model.deploy(
-        entity_url="kubeflow-roles",
-        channel="latest/edge",
-        trust=True,
+        entity_url=KUBEFLOW_ROLES,
+        channel=KUBEFLOW_ROLES_CHANNEL,
+        trust=KUBEFLOW_ROLES_TRUST,
     )
     await ops_test.model.deploy(
-        entity_url="kubeflow-profiles",
-        channel="latest/edge",
-        trust=True,
+        entity_url=KUBEFLOW_PROFILES,
+        channel=KUBEFLOW_PROFILES_CHANNEL,
+        trust=KUBEFLOW_PROFILES_TRUST,
     )
 
     await ops_test.model.wait_for_idle(


### PR DESCRIPTION
Pins dependencies in the integration tests to their corresponding channels for this release.

Ref: https://github.com/canonical/bundle-kubeflow/issues/866

This PR forward-ports the efforts in https://github.com/canonical/training-operator/pull/155 to `main`.