### PR TITLE
ci: use juju 3.4/stable instead of 3.5/stable in track 1.7

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -67,7 +67,7 @@ jobs:
           channel: 1.25-strict/stable
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
           charmcraft-channel: latest/stable
-          juju-channel: 3.5/stable
+          juju-channel: 3.4/stable
 
       - name: Run integration tests
         run: sg snap_microk8s -c "tox -e ${{ matrix.tox-environments }} -- --model testing"


### PR DESCRIPTION
Part of canonical/bundle-kubeflow#944