### PR TITLE
chore: bump training operator to v1.8.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 options:
   training-operator-image:
-    default: kubeflow/training-operator:v1-4485b0a
+    default: kubeflow/training-operator:v1-9e52eb7
     description: |
       Container image to be used by the training-operator workload.
     type: string


### PR DESCRIPTION
closes #181 
brings in the changes from https://github.com/kubeflow/manifests/tree/v1.9.0