### PR TITLE
chore(backport-1.8):  Update tools/get-images.sh to capture images properly

### DIFF
--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -3,7 +3,10 @@
 # This script returns list of container images that are managed by this charm and/or its workload
 #
 # dynamic list
+
+set -xe
+
 IMAGE_LIST=()
-IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
+IMAGE_LIST+=($(find -type f -name config.yaml -exec yq '.options | with_entries(select(.key | test("-image$"))) | .[].default' {} \; | tr -d '"'))
 printf "%s\n" "${IMAGE_LIST[@]}"
 


### PR DESCRIPTION
This PR is a backport of #193 for track/1.18.

It updates `tools/get-images.sh` to capture the needed images properly. The bash script is updated to look at `config.yaml` instead of `metadata.yaml`, and searches all options that match the regular expression "-image$" (meaning all options that end with "image". to capture the value in the `default` key. Note that in our case only 1 value should be captured, but this way is more robust if more images are added in the future.