### PR TITLE
build: pin chisme to >= 0.4.4 to bring grafana test fixes

### DIFF
--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -6,6 +6,8 @@
 #
 anyio==4.5.2
     # via httpx
+appnope==0.1.4
+    # via ipython
 asttokens==3.0.0
     # via stack-data
 attrs==24.2.0
@@ -28,7 +30,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.6
     # via -r requirements-integration.in
 charset-normalizer==3.4.0
     # via requests
@@ -53,7 +55,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10

--- a/requirements-unit.txt
+++ b/requirements-unit.txt
@@ -26,12 +26,10 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
-    # via -r requirements.in
+charmed-kubeflow-chisme==0.4.6
 charset-normalizer==3.4.0
     # via requests
 cosl==0.0.50
-    # via -r requirements.in
 coverage==7.6.1
     # via -r requirements-unit.in
 cryptography==44.0.0
@@ -49,7 +47,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.6
     # via -r requirements.in
 charset-normalizer==3.4.0
     # via requests
@@ -45,7 +45,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10


### PR DESCRIPTION
This commit pins chisme to >= 0.4.4 to avoid an issue with the metrics endpoint. For more information refer to
canonical/charmed-kubeflow-chisme#124.