### PR TITLE
fix: Correct the indentation of integrate.yaml workflow

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -22,9 +22,9 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
     - name: Set up Python 3.12
-        uses: actions/setup-python@v5.6.0
-        with:
-          python-version: "3.12"
+      uses: actions/setup-python@v5.6.0
+      with:
+        python-version: "3.12"
     - name: Install dependencies
       run: pip install tox
 


### PR DESCRIPTION
The CI was not getting triggered as there was an indentation error in the workflow yaml
https://github.com/canonical/training-operator/actions/runs/16113367531