### PR TITLE
chore: update manifests to 1.9.3

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 options:
   training-operator-image:
-    default: charmedkubeflow/training-operator:1.9.0-bf1ad8d
+    default: ghcr.io/kubeflow/training-v1/training-operator:v1-d6eb98e
     description: |
       Container image to be used by the training-operator workload.
     type: string

--- a/src/templates/rbac_manifests.yaml.j2
+++ b/src/templates/rbac_manifests.yaml.j2
@@ -355,6 +355,13 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - localqueues
+  verbs:
+  - get
+  - list
+- apiGroups:
   - ""
   resources:
   - persistentvolumeclaims
@@ -404,6 +411,13 @@ rules:
   - jaxjobs/status
   verbs:
   - get
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - localqueues
+  verbs:
+  - get
+  - list
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Closes #257 

Manifests generated from https://github.com/kubeflow/trainer/tree/v1.9.3. To generate, clone the repo, checkout `v1.9.3` and run the command:
```
kustomize build manifests/overlays/kubeflow > training_manifests.yaml
```
this outputs the manifests to `training_manifests.yaml` for ease of browsing rather than in the terminal. 

## Summary of changes
[Generated diff from v1.9.0 to v1.9.3](https://www.diffchecker.com/8PModiz9/). You can also see in the [tag comparison from 1.9.0 and 1.9.3](https://github.com/kubeflow/trainer/compare/v1.9.0...v1.9.3)
* updated the image
* added `localqueues`  resource to Cluster roles `kubeflow-training-edit` and `kubeflow-training-view`

Note that the rock will be integrated in #258 