### PR TITLE
fix: set `Publish` step as job in CI

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -14,9 +14,33 @@ jobs:
     uses: ./.github/workflows/integrate.yaml
     secrets: inherit
 
-  # publish runs in parallel with tests, as we always publish in this situation
+  destination-channel:
+    runs-on: ubuntu-24.04
+    name: Determine destination channel
+    outputs:
+      destination-channel: ${{ steps.destination-channel.outputs.destination_channel }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Determine destination channel
+        id: destination-channel
+        run: |
+          GIT_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          if [ "${GIT_BRANCH}" = "main-v2" ]; then
+            destination_channel="latest/edge"
+          else
+            destination_channel=''
+          fi
+          echo "destination_channel=$destination_channel" >> "$GITHUB_OUTPUT"
+
+  # publish runs in series with tests, and only publishes if tests passes
   publish-charm:
     name: Publish Charm
+    needs: 
+      - destination-channel
     uses: ./.github/workflows/publish.yaml
     secrets: inherit
-
+    with:
+      destination_channel: ${{ needs.destination-channel.outputs.destination-channel }}

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -20,11 +20,11 @@ jobs:
     uses: ./.github/workflows/integrate.yaml
     secrets: inherit
 
-  # publish runs in series with tests, and only publishes if tests passes
-  publish-charm:
-    name: Publish Charm
+  destination-channel:
     runs-on: ubuntu-24.04
-    needs: tests
+    name: Determine destination channel
+    outputs:
+      destination-channel: ${{ steps.destination-channel.outputs.destination_channel }}
 
     steps:
       - name: Check out code
@@ -41,8 +41,13 @@ jobs:
           fi
           echo "destination_channel=$destination_channel" >> "$GITHUB_OUTPUT"
 
-      - name: Publish Charm
-        uses: ./.github/workflows/publish.yaml
-        with:
-          destination_channel: ${{ steps.destination-channel.outputs.destination_channel }}
-          secrets: inherit
+  # publish runs in series with tests, and only publishes if tests passes
+  publish-charm:
+    name: Publish Charm
+    needs: 
+      - tests
+      - destination-channel
+    uses: ./.github/workflows/publish.yaml
+    secrets: inherit
+    with:
+      destination_channel: ${{ needs.destination-channel.outputs.destination-channel }}


### PR DESCRIPTION
This PR moves the `publish-charm` workflow from a step to a job.

### Publish on push
This job needs both `tests` and `destination-channel` to be run, and uses the output of the latter to determine the charmhub channel to publish the charm to.