### PR TITLE
chore: update terraform modules channel to 2.1/stable

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = "latest/edge"
+  default     = "2.1/stable"
 }
 
 variable "config" {


### PR DESCRIPTION
Closes: https://github.com/canonical/kubeflow-trainer-operator/issues/22