### PR TITLE
backport: bump Rust version to 1.92.0

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -74,7 +74,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging


### PR DESCRIPTION
This PR backports #281 to the `2.1` branch.