### PR TITLE
fix: do not add selector labels to allow seamless upgrade

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -64,7 +64,7 @@ jobs:
           - integration-with-profiles
     steps:
       - name: Maximise GH runner space
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
 
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -21,6 +21,7 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v4
+
     - name: Install dependencies
       run: pipx install tox
 
@@ -85,8 +86,18 @@ jobs:
           kubectl -n kube-system patch configmap cilium-config --type merge --patch '{"data":{"bpf-lb-sock-hostns-only":"true"}}'
           kubectl -n kube-system rollout restart daemonset cilium
   
+      - name: Fetch charm
+        uses: actions/download-artifact@v5
+        with:
+          name: built-charm
+          path: built/
+
+      - name: Get charm path
+        id: charm-path
+        run: echo "charm_path=$(find built/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
+
       - name: Run integration tests
-        run: tox -e ${{ matrix.tox-environment }} -- --model testing
+        run: tox -e ${{ matrix.tox-environment }}  -- --model testing --charm-path="${{ steps.charm-path.outputs.charm_path }}"
 
       - name: Capture k8s resources on failure
         run: |

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -97,7 +97,7 @@ jobs:
         run: echo "charm_path=$(find built/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
 
       - name: Run integration tests
-        run: tox -e ${{ matrix.tox-environment }}  -- --model testing --charm-path="${{ steps.charm-path.outputs.charm_path }}"
+        run: tox -e ${{ matrix.tox-environment }} -- --model testing --charm-path="${{ steps.charm-path.outputs.charm_path }}"
 
       - name: Capture k8s resources on failure
         run: |
@@ -116,11 +116,15 @@ jobs:
         if: failure()
 
       - name: Get secret
-        run: kubectl get secret -ntesting training-operator-webhook-cert -oyaml
+        run: kubectl get secret -n testing training-operator-webhook-cert -oyaml
         if: failure()
 
-      - name: Describe pod
-        run: kubectl describe pod -ntesting -lapp.kubernetes.io/name=training-operator
+      - name: Describe operator pod
+        run: kubectl describe pod -n testing -l app.kubernetes.io/name=training-operator
+        if: failure()
+
+      - name: Describe workload pod
+        run: kubectl describe pod -n testing -l control-plane=testing-training-operator
         if: failure()
 
       - name: Get pods
@@ -128,5 +132,9 @@ jobs:
         if: failure()
 
       - name: Get operator logs
-        run: kubectl logs --tail 100 -ntesting -lapp.kubernetes.io/name=training-operator -ctraining-operator
+        run: kubectl logs --tail 100 -n testing -l app.kubernetes.io/name=training-operator -c charm
+        if: failure()
+
+      - name: Get workload logs
+        run: kubectl logs --tail 100 -n testing -l control-plane=testing-training-operator -c training-operator
         if: failure()

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -43,6 +43,8 @@ jobs:
   # publish runs in parallel with tests, as we always publish in this situation
   publish-charm:
     name: Publish Charm
+    needs:
+      - build-charm
     uses: ./.github/workflows/publish.yaml
     secrets: inherit
 

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -8,9 +8,35 @@ on:
   pull_request:
 
 jobs:
+  build-charm:
+    name: Build charm
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
+        with:
+          channel: 5.21/stable
+
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
+      - name: Build charm under test
+        run: charmcraft pack --verbose
+
+      - name: Archive charm
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-charm
+          path: "*.charm"
+          retention-days: 5
 
   tests:
     name: Run Tests
+    needs: 
+      - build-charm
     uses: ./.github/workflows/integrate.yaml
     secrets: inherit
 

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -14,9 +14,35 @@ on:
     - track/**
 
 jobs:
+  build-charm:
+    name: Build charm
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
+        with:
+          channel: 5.21/stable
+
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
+      - name: Build charm under test
+        run: charmcraft pack --verbose
+
+      - name: Archive charm
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-charm
+          path: "*.charm"
+          retention-days: 5
 
   tests:
     name: Run Tests
+    needs: 
+      - build-charm
     uses: ./.github/workflows/integrate.yaml
     secrets: inherit
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -89,12 +89,23 @@ jobs:
         with:
           channel: latest/stable
 
+      - name: Fetch charm
+        uses: actions/download-artifact@v5
+        with:
+          name: built-charm
+          path: built/
+
+      - name: Get charm path
+        id: charm-path
+        run: echo "charm_path=$(find built/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
+
       - name: Upload charm to charmhubpip-tools
         uses: canonical/charming-actions/upload-charm@2.6.2
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           charm-path: ${{ matrix.charm-path }}
+          built-charm-path: ${{ steps.charm-path.outputs.charm_path }}
           channel: ${{ steps.parse-inputs.outputs.destination_channel }}
           tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}
           charmcraft-channel: 3.x/stable

--- a/src/charm.py
+++ b/src/charm.py
@@ -196,7 +196,7 @@ class TrainingOperatorCharm(CharmBase):
             spec=AuthorizationPolicySpec(
                 selector=WorkloadSelector(
                     # Use the unique label from src/templates/deployment.yaml.j2
-                    matchLabels={"app.kubernetes.io/name": f"{app_name}-manager"},
+                    matchLabels={"control-plane": f"{namespace}-{app_name}"},
                 ),
                 action=Action.allow,
                 rules=[Rule()],

--- a/src/templates/deployment.yaml.j2
+++ b/src/templates/deployment.yaml.j2
@@ -3,8 +3,6 @@ kind: Deployment
 metadata:
   labels:
     control-plane: {{ namespace }}-{{ app_name }}
-    # label added to distinguish charm pod from workload pod
-    app.kubernetes.io/name: {{ app_name }}-manager
   name: {{ app_name }}
   namespace: {{ namespace }}
 spec:
@@ -12,16 +10,12 @@ spec:
   selector:
     matchLabels:
       control-plane: {{ namespace }}-{{ app_name }}
-      # label added to distinguish charm pod from workload pod
-      app.kubernetes.io/name: {{ app_name }}-manager
   template:
     metadata:
       annotations:
         sidecar.istio.io/inject: "false"
       labels:
         control-plane: {{ namespace }}-{{ app_name }}
-        # label added to distinguish charm pod from workload pod
-        app.kubernetes.io/name: {{ app_name }}-manager
     spec:
       containers:
       - command:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from _pytest.config.argparsing import Parser
+
+
+def pytest_addoption(parser: Parser):
+    parser.addoption(
+        "--charm-path",
+        help="Path to charm file for performing tests on.",
+    )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -56,14 +56,17 @@ def lightkube_client() -> Client:
 
 
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test: OpsTest):
+async def test_build_and_deploy(ops_test: OpsTest, request: pytest.FixtureRequest):
     """Build the charm and deploy it with trust=True.
 
     Assert on the unit status.
     """
-    charm_under_test = await ops_test.build_charm(".")
-
-    await ops_test.model.deploy(charm_under_test, application_name=APP_NAME, trust=True)
+    entity_url = (
+        await ops_test.build_charm(".")
+        if not (entity_url := request.config.getoption("--charm-path"))
+        else Path(entity_url).resolve()
+    )
+    await ops_test.model.deploy(entity_url, application_name=APP_NAME, trust=True)
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=60 * 10
     )
@@ -71,7 +74,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     # store charm location in global to be used in other tests
     global CHARM_LOCATION
-    CHARM_LOCATION = charm_under_test
+    CHARM_LOCATION = entity_url
 
     # Deploy grafana-agent for COS integration tests
     await deploy_and_assert_grafana_agent(ops_test.model, APP_NAME, metrics=True)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -3,6 +3,7 @@
 
 import glob
 import logging
+import subprocess
 from pathlib import Path
 
 import lightkube
@@ -93,7 +94,7 @@ async def ensure_training_operator_is_running(ops_test: OpsTest) -> None:
         "wait",
         "--for=condition=ready",
         "pod",
-        "-lapp.kubernetes.io/name=training-operator",
+        f"-l control-plane={ops_test.model_name}-{APP_NAME}",
         f"-n{ops_test.model_name}",
         "--timeout=10m",
         check=True,
@@ -108,7 +109,7 @@ async def ensure_training_operator_is_running(ops_test: OpsTest) -> None:
         "status.phase!=Running",
         check=True,
     )
-    assert "training-operator" not in out
+    assert APP_NAME not in out
 
 
 def lightkube_create_global_resources() -> dict:
@@ -228,6 +229,40 @@ async def test_metrics_endpoint(ops_test: OpsTest):
     await assert_metrics_endpoint(app, metrics_port=METRICS_PORT, metrics_path=METRICS_PATH)
 
 
+def get_deployment_pod_names(model: str, application_name: str) -> list[str]:
+    """Retrieve names of all pods belonging to a specific Juju application.
+
+    This function uses kubectl to query the Kubernetes cluster for pods that match
+    the given application name within the specified Juju model namespace. It filters
+    pods by the label "control-plane".
+
+    Args:
+        model (str): The name of the Juju model, which corresponds to the Kubernetes
+            namespace where the pods are deployed.
+        application_name (str): The name of the Juju application whose pods should
+            be retrieved. This matches the "control-plane" label.
+
+    Returns:
+        list[str]: A list of pod names matching the application. Returns an empty
+            list if no pods are found or if the kubectl command fails.
+    """
+    cmd = [
+        "kubectl",
+        "get",
+        "pods",
+        f"-n{model}",
+        f"-l control-plane={model}-{application_name}",
+        "--no-headers",
+        "-o=custom-columns=NAME:.metadata.name",
+    ]
+    proc = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+    )
+    stdout = proc.stdout.decode("utf8")
+    return stdout.split()
+
+
 def build_pod_container_map(model_name: str, deployment_template: dict) -> dict[str, dict]:
     """Build full map of pods:containers belonging to this charm.
 
@@ -236,7 +271,7 @@ def build_pod_container_map(model_name: str, deployment_template: dict) -> dict[
     `src/templates/deployment.yaml.j2`.
     """
     charm_pods: list = get_pod_names(model_name, APP_NAME)
-    deployment_pods: list = get_pod_names(model_name, f"{APP_NAME}-manager")
+    deployment_pods: list = get_deployment_pod_names(model_name, APP_NAME)
     deployment_container_name = deployment_template["spec"]["template"]["spec"]["containers"][0][
         "name"
     ]
@@ -295,7 +330,7 @@ async def test_remove_with_resources_present(ops_test: OpsTest):
     lightkube_client = lightkube.Client()
     crd_list = lightkube_client.list(
         CustomResourceDefinition,
-        labels=[("app.juju.is/created-by", "training-operator")],
+        labels=[("app.juju.is/created-by", APP_NAME)],
         namespace=ops_test.model_name,
     )
     # testing for empty list (iterator)
@@ -336,7 +371,7 @@ async def test_upgrade(ops_test: OpsTest):
     lightkube_client = lightkube.Client()
     crd_list = lightkube_client.list(
         CustomResourceDefinition,
-        labels=[("app.juju.is/created-by", "training-operator")],
+        labels=[("app.juju.is/created-by", APP_NAME)],
         namespace=ops_test.model_name,
     )
     # testing for non empty list (iterator)
@@ -383,7 +418,7 @@ async def test_remove_without_resources(ops_test: OpsTest):
     lightkube_client = lightkube.Client()
     crd_list = lightkube_client.list(
         CustomResourceDefinition,
-        labels=[("app.juju.is/created-by", "training-operator")],
+        labels=[("app.juju.is/created-by", APP_NAME)],
         namespace=ops_test.model_name,
     )
     for crd in crd_list:

--- a/tests/integration/test_charm_ambient.py
+++ b/tests/integration/test_charm_ambient.py
@@ -3,6 +3,7 @@
 
 import glob
 import logging
+import subprocess
 from pathlib import Path
 
 import lightkube
@@ -99,7 +100,7 @@ async def ensure_training_operator_is_running(ops_test: OpsTest) -> None:
         "wait",
         "--for=condition=ready",
         "pod",
-        "-lapp.kubernetes.io/name=training-operator",
+        f"-l control-plane={ops_test.model_name}-{APP_NAME}",
         f"-n{ops_test.model_name}",
         "--timeout=10m",
         check=True,
@@ -234,6 +235,40 @@ async def test_metrics_endpoint(ops_test: OpsTest):
     await assert_metrics_endpoint(app, metrics_port=METRICS_PORT, metrics_path=METRICS_PATH)
 
 
+def get_deployment_pod_names(model: str, application_name: str) -> list[str]:
+    """Retrieve names of all pods belonging to a specific Juju application.
+
+    This function uses kubectl to query the Kubernetes cluster for pods that match
+    the given application name within the specified Juju model namespace. It filters
+    pods by the label "control-plane".
+
+    Args:
+        model (str): The name of the Juju model, which corresponds to the Kubernetes
+            namespace where the pods are deployed.
+        application_name (str): The name of the Juju application whose pods should
+            be retrieved. This matches the "control-plane" label.
+
+    Returns:
+        list[str]: A list of pod names matching the application. Returns an empty
+            list if no pods are found or if the kubectl command fails.
+    """
+    cmd = [
+        "kubectl",
+        "get",
+        "pods",
+        f"-n{model}",
+        f"-l control-plane={model}-{application_name}",
+        "--no-headers",
+        "-o=custom-columns=NAME:.metadata.name",
+    ]
+    proc = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+    )
+    stdout = proc.stdout.decode("utf8")
+    return stdout.split()
+
+
 def build_pod_container_map(model_name: str, deployment_template: dict) -> dict[str, dict]:
     """Build full map of pods:containers belonging to this charm.
 
@@ -242,7 +277,7 @@ def build_pod_container_map(model_name: str, deployment_template: dict) -> dict[
     `src/templates/deployment.yaml.j2`.
     """
     charm_pods: list = get_pod_names(model_name, APP_NAME)
-    deployment_pods: list = get_pod_names(model_name, f"{APP_NAME}-manager")
+    deployment_pods: list = get_deployment_pod_names(model_name, APP_NAME)
     deployment_container_name = deployment_template["spec"]["template"]["spec"]["containers"][0][
         "name"
     ]
@@ -301,7 +336,7 @@ async def test_remove_with_resources_present(ops_test: OpsTest):
     lightkube_client = lightkube.Client()
     crd_list = lightkube_client.list(
         CustomResourceDefinition,
-        labels=[("app.juju.is/created-by", "training-operator")],
+        labels=[("app.juju.is/created-by", APP_NAME)],
         namespace=ops_test.model_name,
     )
     # testing for empty list (iterator)
@@ -342,7 +377,7 @@ async def test_upgrade(ops_test: OpsTest):
     lightkube_client = lightkube.Client()
     crd_list = lightkube_client.list(
         CustomResourceDefinition,
-        labels=[("app.juju.is/created-by", "training-operator")],
+        labels=[("app.juju.is/created-by", APP_NAME)],
         namespace=ops_test.model_name,
     )
     # testing for non empty list (iterator)

--- a/tests/integration/test_charm_with_profile.py
+++ b/tests/integration/test_charm_with_profile.py
@@ -38,11 +38,17 @@ log = logging.getLogger(__name__)
 
 
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test: OpsTest):
-    """Build the charm and deploy."""
-    charm_under_test = await ops_test.build_charm(".")
+async def test_build_and_deploy(ops_test: OpsTest, request: pytest.FixtureRequest):
+    """Build the charm and deploy it with trust=True.
 
-    await ops_test.model.deploy(charm_under_test, application_name=APP_NAME, trust=True)
+    Assert on the unit status.
+    """
+    entity_url = (
+        await ops_test.build_charm(".")
+        if not (entity_url := request.config.getoption("--charm-path"))
+        else Path(entity_url).resolve()
+    )
+    await ops_test.model.deploy(entity_url, application_name=APP_NAME, trust=True)
 
     # Deploy kubeflow-roles and kubeflow-profiles to create a Profile
     await ops_test.model.deploy(


### PR DESCRIPTION
This PR removes the newly added label `app.kubernetes.io/name` from the `Deployment`.
This change is required since labels are immutable and therefore the charm upgrade fails.
An additional helper function, named `get_deployment_pod_names`, is required to retrieve the pod matching the `control-plane` label.
Label selector required for Service Mesh is updated to use the `control-plane` label, which only matches the training manager (not the charm agent pod).
Using such label, we are able to identify only the workload pod:
```
kubectl get pods -A -l "control-plane=kubeflow-training-operator"
NAMESPACE   NAME                                 READY   STATUS    RESTARTS   AGE
kubeflow    training-operator-6f8d557494-rbsjq   1/1     Running   0          151m
```
The charm pod is instead matched with the `app.kubernetes.io/name` label:
```
kubectl get pods -A -l "app.kubernetes.io/name=training-operator" 
NAMESPACE   NAME                  READY   STATUS    RESTARTS   AGE
kubeflow    training-operator-0   1/1     Running   0          154m
```

This PR closes #294.