### PR TITLE
fix: add label to clustertrainingruntimes to disable ambient

### DIFF
--- a/src/training_runtimes/deepspeed_distributed.yaml
+++ b/src/training_runtimes/deepspeed_distributed.yaml
@@ -37,6 +37,7 @@ spec:
                 metadata:
                   labels:
                     sidecar.istio.io/inject: 'false'
+                    # Opt out of Istio ambient mesh to enable pod-to-pod communication for distributed training.
                     istio.io/dataplane-mode: none
                 spec:
                   containers:

--- a/src/training_runtimes/deepspeed_distributed.yaml
+++ b/src/training_runtimes/deepspeed_distributed.yaml
@@ -37,6 +37,7 @@ spec:
                 metadata:
                   labels:
                     sidecar.istio.io/inject: 'false'
+                    istio.io/dataplane-mode: none
                 spec:
                   containers:
                     - name: node

--- a/src/training_runtimes/mlx_distributed.yaml
+++ b/src/training_runtimes/mlx_distributed.yaml
@@ -40,6 +40,7 @@ spec:
                 metadata:
                   labels:
                     sidecar.istio.io/inject: 'false'
+                    # Opt out of Istio ambient mesh to enable pod-to-pod communication for distributed training.
                     istio.io/dataplane-mode: none
                 spec:
                   containers:

--- a/src/training_runtimes/mlx_distributed.yaml
+++ b/src/training_runtimes/mlx_distributed.yaml
@@ -40,6 +40,7 @@ spec:
                 metadata:
                   labels:
                     sidecar.istio.io/inject: 'false'
+                    istio.io/dataplane-mode: none
                 spec:
                   containers:
                     - name: node

--- a/src/training_runtimes/mpi_distributed.yaml
+++ b/src/training_runtimes/mpi_distributed.yaml
@@ -47,6 +47,7 @@ spec:
                 metadata:
                   labels:
                     sidecar.istio.io/inject: 'false'
+                    istio.io/dataplane-mode: none
                 spec:
                   containers:
                     - name: node

--- a/src/training_runtimes/mpi_distributed.yaml
+++ b/src/training_runtimes/mpi_distributed.yaml
@@ -47,6 +47,7 @@ spec:
                 metadata:
                   labels:
                     sidecar.istio.io/inject: 'false'
+                    # Opt out of Istio ambient mesh to enable pod-to-pod communication for distributed training.
                     istio.io/dataplane-mode: none
                 spec:
                   containers:

--- a/src/training_runtimes/torch_distributed.yaml
+++ b/src/training_runtimes/torch_distributed.yaml
@@ -22,6 +22,7 @@ spec:
               metadata:
                 labels:
                   sidecar.istio.io/inject: 'false'
+                  istio.io/dataplane-mode: none
               spec:
                 containers:
                 - image: pytorch/pytorch:2.7.1-cuda12.8-cudnn9-runtime

--- a/src/training_runtimes/torch_distributed.yaml
+++ b/src/training_runtimes/torch_distributed.yaml
@@ -22,6 +22,7 @@ spec:
               metadata:
                 labels:
                   sidecar.istio.io/inject: 'false'
+                  # Opt out of Istio ambient mesh to enable pod-to-pod communication for distributed training.
                   istio.io/dataplane-mode: none
               spec:
                 containers:


### PR DESCRIPTION
Part of #297 
Follow-up for #293

This PR adds the label `istio.io/dataplane-mode: none` to the `ClusterTrainingRuntime` templates of `kubeflow-trainer`. This is needed to ensure the pods of the various training jobs are not included in the mesh, due to the distributed training doing direct pod-to-pod communication that cannot go through the waypoint. 

## Testing (including upgrade testing)
1. Deploy the charm from `latest/edge`, its dependencies, and ambient charms. You can use this bundle as reference:
```
bundle: kubernetes
applications:
  admission-webhook:
    charm: admission-webhook
    channel: latest/edge
    revision: 586
    resources:
      oci-image: 297
    scale: 1
    constraints: arch=amd64
    trust: true
  istio-beacon-k8s:
    charm: istio-beacon-k8s
    channel: 2/edge
    revision: 63
    base: ubuntu@22.04/stable
    resources:
      metrics-proxy-image: 3
    scale: 1
    constraints: arch=amd64
    trust: true
  istio-ingress-k8s:
    charm: istio-ingress-k8s
    channel: 2/edge
    revision: 61
    resources:
      metrics-proxy-image: 3
    scale: 1
    constraints: arch=amd64
    trust: true
  istio-k8s:
    charm: istio-k8s
    channel: 2/edge
    revision: 45
    resources:
      metrics-proxy-image: 2
    scale: 1
    options:
      platform: ""
    constraints: arch=amd64
    trust: true
  kubeflow-dashboard:
    charm: kubeflow-dashboard
    channel: latest/edge
    revision: 953
    resources:
      oci-image: 701
    scale: 1
    constraints: arch=amd64
    trust: true
  kubeflow-profiles:
    charm: kubeflow-profiles
    channel: latest/edge
    revision: 820
    resources:
      kfam-image: 583
      profile-image: 585
    scale: 1
    options:
      istio-gateway-principal: cluster.local/ns/kubeflow/sa/istio-ingress-k8s-istio
      service-mesh-mode: istio-ambient
    constraints: arch=amd64
    storage:
      config-profiles: kubernetes,1,1M
    trust: true
  kubeflow-roles:
    charm: kubeflow-roles
    channel: latest/edge
    revision: 401
    scale: 1
    constraints: arch=amd64
    trust: true
  kubeflow-trainer:
    charm: kubeflow-trainer
    channel: latest/edge
    revision: 74
    scale: 1
    constraints: arch=amd64
    trust: true
relations:
- - istio-ingress-k8s:istio-ingress-config
  - istio-k8s:istio-ingress-config
- - admission-webhook:service-mesh
  - istio-beacon-k8s:service-mesh
- - istio-ingress-k8s:istio-ingress-route
  - kubeflow-dashboard:istio-ingress-route
- - istio-beacon-k8s:service-mesh
  - kubeflow-dashboard:service-mesh
- - istio-beacon-k8s:service-mesh
  - kubeflow-profiles:service-mesh
- - kubeflow-dashboard:kubeflow-profiles
  - kubeflow-profiles:kubeflow-profiles
- - kubeflow-trainer:service-mesh
  - istio-beacon-k8s:service-mesh
```
2. Refresh `kubeflow-trainer` to the charm from this PR:
```
juju refresh kubeflow-trainer --channel=latest/edge/pr-298
```
3. Check that the `ClusterTrainingRuntime` resources were updated with the label with no issues:
```
kubectl get clustertrainingruntimes.trainer.kubeflow.org -n kubeflow -o yaml | grep istio.io/dataplane-mode
                    istio.io/dataplane-mode: none
                    istio.io/dataplane-mode: none
                    istio.io/dataplane-mode: none
                    istio.io/dataplane-mode: none
```
4. Create a `Profile` using the yaml:
```
apiVersion: kubeflow.org/v1
kind: Profile
metadata:
  name: profilename
spec:
  owner:
    kind: User
    name: userid@email.com
```
5. Create a `TrainJob` of any runtime in the profile namespace, for example use [this yaml](https://github.com/canonical/training-operator/blob/main-v2/examples/trainjob-pytorch.yaml) and apply it with:
```
kubectl apply -n profilename -f ./trainjob-pytorch.yaml
```
6. Make sure the `TrainJob` completed successfully:
```
kubectl get trainjobs.trainer.kubeflow.org -n profilename 
NAME             STATE      AGE
pytorch-simple   Complete   4m32s
```