### PR TITLE
chore: pin charm dependencies in tests (track/2.0)

### DIFF
--- a/tests/integration/charms_dependencies.py
+++ b/tests/integration/charms_dependencies.py
@@ -2,6 +2,6 @@
 
 from charmed_kubeflow_chisme.testing import CharmSpec
 
-KUBEFLOW_PROFILES = CharmSpec(charm="kubeflow-profiles", channel="latest/edge", trust=True)
-KUBEFLOW_ROLES = CharmSpec(charm="kubeflow-roles", channel="latest/edge", trust=True)
-ISTIO_PILOT = CharmSpec(charm="istio-pilot", channel="latest/edge", trust=True)
+KUBEFLOW_PROFILES = CharmSpec(charm="kubeflow-profiles", channel="1.10/edge", trust=True)
+KUBEFLOW_ROLES = CharmSpec(charm="kubeflow-roles", channel="1.10/edge", trust=True)
+ISTIO_PILOT = CharmSpec(charm="istio-pilot", channel="1.24/edge", trust=True)


### PR DESCRIPTION
This PR pins the track of charm dependencies in tests.

### External (resolved via Terraform Solutions track/1.10)
- `kubeflow-profiles`: `latest/edge` → `1.10/edge`
- `kubeflow-roles`: `latest/edge` → `1.10/edge`
- `istio-pilot`: `latest/edge` → `1.24/edge`

Refs: canonical/bundle-kubeflow#1379
