### PR TITLE
chore: remove lib checks

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -8,13 +8,6 @@ on:
         required: true
 
 jobs:
-  quality-checks:
-    name: Quality checks
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_quality-checks.yaml@main
-    secrets: inherit
-    with:
-        charm-path: "."
-
   lint:
     name: Lint
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This PR removes the `check lib` CI job which is no longer needed.

### Removed jobs
- `lib-check` in `.github/workflows/integrate.yaml`

Refs: canonical/bundle-kubeflow#1439